### PR TITLE
Harden query refresh and block UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ obsidian eval code="app.plugins.getPlugin('duckdb-motherduck').api.refreshFile('
 
 ```sh
 npm install
+npm test         # automated unit tests for parser/cache/table helpers
 npm run build     # production bundle, main.js
 npm run dev       # watch mode, rebuilds on save
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Works entirely offline with local DuckDB WASM. Add a MotherDuck token to query y
 
 - **`duckdb` / `motherduck` code blocks**: render a SQL panel in reading mode with a ▶ Run button and a connection badge showing which engine the block runs against.
 - **Freeze**: "Freeze query at cursor" or the 📌 button in reading mode runs the query and writes the result as a markdown table directly below the block, bracketed by sentinel comments.
-- **Refresh**: "Refresh all queries in this note" re-runs every frozen block. Unchanged SQL keeps its cached output; edited SQL re-runs.
+- **Refresh**: "Refresh all queries in this note" re-runs every SQL block and replaces its frozen output.
 - **Scheduled refresh**: pick a daily / weekly cadence per note via the per-block dropdown; the plugin sweeps once an hour while Obsidian runs and refreshes overdue notes automatically. Activity log + manual "Refresh now" button in plugin settings.
 - **Plugin API**: `app.plugins.getPlugin('duckdb-motherduck').api.refreshFile(path)` and `.runQuery(sql, connection?)` (where `connection` is `"local"` or `"cloud"`, defaulting to `"local"`), so Claude Code or other agents can trigger refreshes via `obsidian eval`.
 
@@ -18,7 +18,7 @@ Works entirely offline with local DuckDB WASM. Add a MotherDuck token to query y
 ```motherduck
 SELECT brand, SUM(revenue) FROM sales GROUP BY 1 ORDER BY 2 DESC LIMIT 10
 ```
-<!-- md:cache hash=a3f847b2 ts=2026-04-24T14:22:00Z rows=10 -->
+<!-- md:cache hash=a3f847b2 conn=cloud ts=2026-04-24T14:22:00Z rows=10 -->
 
 | brand | sum(revenue) |
 | ----- | ------------ |
@@ -28,7 +28,7 @@ SELECT brand, SUM(revenue) FROM sales GROUP BY 1 ORDER BY 2 DESC LIMIT 10
 <!-- md:cache-end -->
 ````
 
-The sentinel carries a SQL hash, timestamp, and row count. Editing the SQL changes the hash, the next refresh re-runs that block. Leaving it alone keeps the cache.
+The sentinel carries a query hash, connection, timestamp, and row count. Refresh/freeze replaces the sentinel block below the query.
 
 ## Connections
 
@@ -59,7 +59,7 @@ The plugin isn't in the Obsidian community store yet. To install:
 
 1. Clone this repo.
 2. `npm install && npm run build`, produces `main.js`.
-3. Copy `main.js` and `manifest.json` into `<your-vault>/.obsidian/plugins/duckdb-motherduck/`.
+3. Copy `main.js`, `manifest.json`, and `styles.css` into `<your-vault>/.obsidian/plugins/duckdb-motherduck/`.
 4. In Obsidian: Settings → Community plugins → enable *DuckDB & MotherDuck*.
 
 ## Usage

--- a/main.ts
+++ b/main.ts
@@ -1,97 +1,45 @@
+import { MarkdownPostProcessorContext, MarkdownView, Notice, Plugin, TFile } from "obsidian";
+import { FileLock } from "./src/file-lock";
+import { findBlocks, writeSentinelAfterBlock, type FencedBlock } from "./src/markdown";
+import { renderQueryBlock } from "./src/query-block";
+import { RuntimeManager } from "./src/runtime/manager";
+import { isOverdue } from "./src/schedule";
+import { SettingsTab } from "./src/settings-tab";
+import { renderMarkdownTable } from "./src/table";
 import {
-  App,
-  MarkdownPostProcessorContext,
-  MarkdownView,
-  Notice,
-  Plugin,
-  PluginSettingTab,
-  Setting,
-  TFile,
-  setIcon,
-} from "obsidian";
-import { Row, Runtime } from "./src/runtime";
-import { DuckDBWasmRuntime } from "./src/runtime/duckdb";
-import { MotherDuckRuntime } from "./src/runtime/motherduck";
-import { DUCKDB_ICON, MOTHERDUCK_ICON } from "./src/icons";
-
-type Connection = "local" | "cloud";
-type Cadence = "daily" | "weekly";
-
-const CADENCE_MS: Record<Cadence, number> = {
-  daily: 24 * 60 * 60 * 1000,
-  weekly: 7 * 24 * 60 * 60 * 1000,
-};
-
-const SWEEP_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
-const STARTUP_DELAY_MS = 5 * 1000; // delay before the first post-load sweep
-const LOG_CAP = 100;
-
-interface RefreshLogEntry {
-  ts: string; // ISO timestamp
-  path: string;
-  trigger: "schedule" | "manual";
-  blocks: number;
-  errored: number;
-  errorMessage?: string; // top-level error if the refresh threw before producing per-block counts
-}
-
-interface Settings {
-  mdToken: string;
-  dbPath: string;
-  rowCap: number;
-  scheduleEnabled: boolean;
-  refreshLog: RefreshLogEntry[];
-}
-
-const DEFAULTS: Settings = {
-  mdToken: "",
-  dbPath: ":memory:",
-  rowCap: 100,
-  scheduleEnabled: false,
-  refreshLog: [],
-};
+  DEFAULTS,
+  LOG_CAP,
+  STARTUP_DELAY_MS,
+  SWEEP_INTERVAL_MS,
+  type Cadence,
+  type Connection,
+  type QueryRunResult,
+  type RefreshLogEntry,
+  type Settings,
+  type SweepResult,
+} from "./src/types";
 
 export default class MotherDuckPlugin extends Plugin {
   settings!: Settings;
-  // One cached runtime per connection. They're independent: changing the local
-  // db path resets only the local runtime, changing the token resets only the
-  // cloud one. Queries on different connections in the same note coexist.
-  private localRuntime: Runtime | null = null;
-  private cloudRuntime: Runtime | null = null;
-  private localRuntimePromise: Promise<Runtime> | null = null;
-  private cloudRuntimePromise: Promise<Runtime> | null = null;
-  private runtimeGeneration: Record<Connection, number> = {
-    local: 0,
-    cloud: 0,
-  };
-  private queryQueues: Record<Connection, Promise<unknown>> = {
-    local: Promise.resolve(),
-    cloud: Promise.resolve(),
-  };
-  private fileLocks = new Map<string, Promise<void>>();
-  // Scheduler state. `sweepInterval` is the setInterval ID (or null when the
-  // scheduler is off); `sweepRunning` prevents overlapping sweeps if a previous
-  // one is still working when the next interval fires.
+  private runtimeManager = new RuntimeManager(() => this.settings);
+  private fileLocks = new FileLock();
   private sweepTimeout: number | null = null;
   private sweepInterval: number | null = null;
   private sweepRunning = false;
   api!: {
     refreshFile: (path: string) => Promise<string>;
-    runQuery: (sql: string, connection?: Connection) => Promise<{ rows: Row[]; columns: string[] }>;
+    runQuery: (sql: string, connection?: Connection) => Promise<QueryRunResult>;
   };
 
   async onload() {
     await this.loadSettings();
     this.addSettingTab(new SettingsTab(this.app, this));
 
-    // Two fence types, same render pipeline. The connection arg is the only
-    // thing that varies; everything below it (run / freeze / table render) is
-    // identical regardless of which engine the SQL lands on.
     this.registerMarkdownCodeBlockProcessor("duckdb", (src, el, ctx) =>
-      this.renderBlock("local", src, el, ctx),
+      renderQueryBlock(this, "local", src, el, ctx),
     );
     this.registerMarkdownCodeBlockProcessor("motherduck", (src, el, ctx) =>
-      this.renderBlock("cloud", src, el, ctx),
+      renderQueryBlock(this, "cloud", src, el, ctx),
     );
 
     this.addCommand({
@@ -148,31 +96,6 @@ export default class MotherDuckPlugin extends Plugin {
     await this.resetRuntimes();
   }
 
-  async resetRuntimes(only?: Connection) {
-    if (!only || only === "local") {
-      this.runtimeGeneration.local++;
-      this.localRuntimePromise = null;
-      this.queryQueues.local = Promise.resolve();
-      try {
-        await this.localRuntime?.close();
-      } catch (e) {
-        console.error("[motherduck] close local failed", e);
-      }
-      this.localRuntime = null;
-    }
-    if (!only || only === "cloud") {
-      this.runtimeGeneration.cloud++;
-      this.cloudRuntimePromise = null;
-      this.queryQueues.cloud = Promise.resolve();
-      try {
-        await this.cloudRuntime?.close();
-      } catch (e) {
-        console.error("[motherduck] close cloud failed", e);
-      }
-      this.cloudRuntime = null;
-    }
-  }
-
   async loadSettings() {
     this.settings = Object.assign({}, DEFAULTS, await this.loadData());
   }
@@ -181,144 +104,20 @@ export default class MotherDuckPlugin extends Plugin {
     await this.saveData(this.settings);
   }
 
-  // ----------------- runtime -----------------
-
-  async getRuntime(connection: Connection): Promise<Runtime> {
-    if (connection === "cloud") {
-      if (!this.settings.mdToken) {
-        throw new Error("MotherDuck token not set. Configure it in plugin settings.");
-      }
-      if (this.cloudRuntime) return this.cloudRuntime;
-      if (!this.cloudRuntimePromise) {
-        const rt = new MotherDuckRuntime(this.settings.mdToken);
-        const generation = this.runtimeGeneration.cloud;
-        this.cloudRuntimePromise = rt
-          .init()
-          .then(() => {
-            if (this.runtimeGeneration.cloud !== generation) {
-              void rt.close();
-              throw new Error("MotherDuck connection reset while initializing. Retry the query.");
-            }
-            this.cloudRuntime = rt;
-            return rt;
-          })
-          .catch(async (e) => {
-            await rt.close().catch((closeError) => {
-              console.error("[motherduck] close failed after cloud init error", closeError);
-            });
-            throw e;
-          })
-          .finally(() => {
-            this.cloudRuntimePromise = null;
-          });
-      }
-      return this.cloudRuntimePromise;
-    }
-    if (this.localRuntime) return this.localRuntime;
-    if (!this.localRuntimePromise) {
-      const rt = new DuckDBWasmRuntime(this.settings.dbPath);
-      const generation = this.runtimeGeneration.local;
-      this.localRuntimePromise = rt
-        .init()
-          .then(() => {
-            if (this.runtimeGeneration.local !== generation) {
-              void rt.close();
-              throw new Error("DuckDB connection reset while initializing. Retry the query.");
-            }
-            this.localRuntime = rt;
-            return rt;
-          })
-          .catch(async (e) => {
-            await rt.close().catch((closeError) => {
-              console.error("[motherduck] close failed after local init error", closeError);
-            });
-            throw e;
-          })
-          .finally(() => {
-            this.localRuntimePromise = null;
-          });
-    }
-    return this.localRuntimePromise;
+  async resetRuntimes(only?: Connection) {
+    await this.runtimeManager.reset(only);
   }
 
-  async runQuery(sql: string, connection: Connection): Promise<{ rows: Row[]; columns: string[] }> {
-    return this.enqueueQuery(connection, async () => {
-      const rt = await this.getRuntime(connection);
-      return rt.runQuery(sql);
-    });
+  async runQuery(sql: string, connection: Connection): Promise<QueryRunResult> {
+    return this.runtimeManager.runQuery(sql, connection);
   }
-
-  private enqueueQuery<T>(connection: Connection, op: () => Promise<T>): Promise<T> {
-    const previous = this.queryQueues[connection].catch(() => undefined);
-    const next = previous.then(op);
-    this.queryQueues[connection] = next.catch(() => undefined);
-    return next;
-  }
-
-  // Append a small <select> to the given parent, mapped to the host note's
-  // `duckdb-motherduck-refresh` frontmatter. None / Daily / Weekly. Selecting
-  // None removes the property; selecting a cadence sets it. Updates persist via
-  // Obsidian's processFrontMatter, which preserves YAML structure and other keys.
-  private attachRefreshDropdown(parent: HTMLElement, ctx: MarkdownPostProcessorContext) {
-    const sourcePath = ctx.sourcePath;
-    const file = this.app.vault.getAbstractFileByPath(sourcePath);
-    if (!(file instanceof TFile)) return;
-
-    // Group the icon + dropdown together and right-align as a unit, so the
-    // icon is visually attached to the select rather than floating between
-    // the badge label and the picker.
-    const group = parent.createDiv({ cls: "motherduck-refresh-control" });
-
-    const iconHost = group.createDiv({ cls: "motherduck-refresh-control__icon" });
-    setIcon(iconHost, "refresh-cw");
-
-    const select = group.createEl("select", { cls: "motherduck-refresh-control__select" }) as HTMLSelectElement;
-    select.title = "Auto-refresh this note (writes to its frontmatter)";
-    select.setAttr("aria-label", "Auto-refresh this note");
-
-    const opts: Array<{ value: "" | Cadence; label: string }> = [
-      { value: "", label: "Refresh: none" },
-      { value: "daily", label: "Refresh: daily" },
-      { value: "weekly", label: "Refresh: weekly" },
-    ];
-    for (const opt of opts) {
-      const o = select.createEl("option");
-      o.value = opt.value;
-      o.text = opt.label;
-    }
-
-    // Initialize from existing frontmatter.
-    const fm = this.app.metadataCache.getFileCache(file)?.frontmatter;
-    const current = fm?.["duckdb-motherduck-refresh"];
-    select.value = current === "daily" || current === "weekly" ? current : "";
-
-    select.addEventListener("change", async () => {
-      const v = select.value as "" | Cadence;
-      try {
-        await this.app.fileManager.processFrontMatter(file, (fmEdit) => {
-          if (v === "") {
-            delete fmEdit["duckdb-motherduck-refresh"];
-          } else {
-            fmEdit["duckdb-motherduck-refresh"] = v;
-          }
-        });
-      } catch (e) {
-        console.error("[motherduck] failed to update refresh cadence frontmatter", e);
-        new Notice("failed to update refresh cadence");
-      }
-    });
-  }
-
-  // ----------------- scheduler -----------------
 
   startScheduler() {
     if (this.sweepInterval !== null || this.sweepTimeout !== null) return;
-    // Initial post-load sweep, after a short delay to let Obsidian finish booting.
     this.sweepTimeout = window.setTimeout(() => {
       this.sweepTimeout = null;
       if (this.settings.scheduleEnabled) void this.runScheduledSweep();
     }, STARTUP_DELAY_MS);
-    // Then sweep at the regular interval.
     this.sweepInterval = this.registerInterval(
       window.setInterval(() => {
         if (this.settings.scheduleEnabled) void this.runScheduledSweep();
@@ -337,12 +136,7 @@ export default class MotherDuckPlugin extends Plugin {
     }
   }
 
-  // Schedule-driven sweep: only opt-in notes (those with the
-  // `duckdb-motherduck-refresh` frontmatter property), respects each note's
-  // cadence so we only touch ones that are actually overdue. Updates
-  // `duckdb-motherduck-refresh-last` after each successful refresh so the
-  // next cadence window starts from now.
-  async runScheduledSweep(): Promise<{ refreshed: number; errored: number; checked: number }> {
+  async runScheduledSweep(): Promise<SweepResult> {
     return this.runSweepInternal({
       trigger: "schedule",
       candidates: this.discoverScheduledNotes(),
@@ -351,12 +145,7 @@ export default class MotherDuckPlugin extends Plugin {
     });
   }
 
-  // Manual sweep, the user clicked the button. Refreshes every note in the
-  // vault that contains a SQL block, regardless of frontmatter opt-in. Doesn't
-  // touch the last-refresh timestamp on notes that aren't opted in (they have
-  // no cadence, so a `last` value would be meaningless), but does update it on
-  // ones that are, so a manual click also resets their cadence window.
-  async runManualSweep(): Promise<{ refreshed: number; errored: number; checked: number }> {
+  async runManualSweep(): Promise<SweepResult> {
     const all = await this.discoverNotesWithBlocks();
     const optedIn = new Set(this.discoverScheduledNotes().map((c) => c.file.path));
     return this.runSweepInternal({
@@ -368,31 +157,121 @@ export default class MotherDuckPlugin extends Plugin {
     });
   }
 
+  async refreshFile(path: string): Promise<string> {
+    const r = await this.refreshFileDetailed(path);
+    return `Refreshed ${r.refreshed} block(s), ${r.errored} error(s) in ${path}`;
+  }
+
+  async refreshFileDetailed(
+    path: string,
+  ): Promise<{ refreshed: number; errored: number; firstError?: string }> {
+    return this.fileLocks.run(path, async () => {
+      const file = this.app.vault.getAbstractFileByPath(path);
+      if (!(file instanceof TFile)) throw new Error(`not a file: ${path}`);
+      const content = await this.app.vault.read(file);
+      const result = await this.processAllBlocks(content);
+      await this.modifyIfUnchanged(file, content, result.newContent);
+      return { refreshed: result.refreshed, errored: result.errored, firstError: result.firstError };
+    });
+  }
+
+  async freezeAtCursor(file: TFile, cursorLine: number): Promise<string> {
+    return this.fileLocks.run(file.path, async () => {
+      const content = await this.app.vault.read(file);
+      const blocks = findBlocks(content);
+      const hit = blocks.find((b) => cursorLine >= b.startLine && cursorLine <= b.endLine);
+      if (!hit) throw new Error("no ```duckdb or ```motherduck block at cursor");
+      const newContent = await this.freezeBlock(content, hit);
+      await this.modifyIfUnchanged(file, content, newContent);
+      return "Froze 1 block";
+    });
+  }
+
+  async freezeRenderedBlock(
+    ctx: MarkdownPostProcessorContext,
+    el: HTMLElement,
+    sql: string,
+    connection: Connection,
+  ): Promise<void> {
+    const file = this.app.vault.getAbstractFileByPath(ctx.sourcePath);
+    if (!(file instanceof TFile)) throw new Error(`not a file: ${ctx.sourcePath}`);
+
+    await this.fileLocks.run(file.path, async () => {
+      const info = ctx.getSectionInfo(el);
+      if (!info) throw new Error("cannot locate block position");
+      const content = await this.app.vault.read(file);
+      const block =
+        findBlocks(content).find(
+          (candidate) => candidate.startLine === info.lineStart && candidate.endLine === info.lineEnd,
+        ) ?? { sql, startLine: info.lineStart, endLine: info.lineEnd, connection };
+      const newContent = await this.freezeBlock(content, block);
+      await this.modifyIfUnchanged(file, content, newContent);
+    });
+  }
+
+  async processAllBlocks(
+    content: string,
+  ): Promise<{ newContent: string; refreshed: number; errored: number; firstError?: string }> {
+    const blocks = findBlocks(content);
+    let working = content;
+    let refreshed = 0;
+    let errored = 0;
+    let firstError: string | undefined;
+
+    for (let i = blocks.length - 1; i >= 0; i--) {
+      try {
+        working = await this.freezeBlock(working, blocks[i]);
+        refreshed++;
+      } catch (e) {
+        console.error("[motherduck] block error", e);
+        errored++;
+        if (!firstError) firstError = e instanceof Error ? e.message : String(e);
+      }
+    }
+
+    return { newContent: working, refreshed, errored, firstError };
+  }
+
+  async freezeBlock(content: string, block: FencedBlock): Promise<string> {
+    const { rows, columns } = await this.runQuery(block.sql, block.connection);
+    const mdTable = renderMarkdownTable(
+      rows,
+      columns,
+      block.sql,
+      block.connection,
+      this.settings.rowCap,
+    );
+    return writeSentinelAfterBlock(content, block, mdTable);
+  }
+
   private async runSweepInternal(opts: {
     trigger: "schedule" | "manual";
     candidates: Array<{ file: TFile; cadence: Cadence | null; lastRefresh: string | null }>;
     ignoreCadence: boolean;
     stampLastOnSuccess: boolean;
     stampPredicate?: (file: TFile) => boolean;
-  }): Promise<{ refreshed: number; errored: number; checked: number }> {
+  }): Promise<SweepResult> {
     if (this.sweepRunning) {
       console.log("[motherduck] sweep skipped: previous sweep still running");
       return { refreshed: 0, errored: 0, checked: 0 };
     }
+
     this.sweepRunning = true;
     let refreshed = 0;
     let errored = 0;
     let checked = 0;
+
     try {
       for (const { file, cadence, lastRefresh } of opts.candidates) {
         checked++;
         if (!opts.ignoreCadence && cadence && !isOverdue(cadence, lastRefresh)) continue;
-        // Don't stomp on a note the user is currently editing.
+
         const activeFile = this.app.workspace.getActiveFile();
         if (activeFile?.path === file.path) {
           console.log(`[motherduck] sweep: skipping ${file.path}, active editor`);
           continue;
         }
+
         try {
           const result = await this.refreshFileDetailed(file.path);
           const shouldStamp =
@@ -424,19 +303,15 @@ export default class MotherDuckPlugin extends Plugin {
             errorMessage: msg,
           });
           errored++;
-          // Leave the last-refresh timestamp alone so the next sweep retries
-          // instead of waiting a full cadence.
         }
       }
     } finally {
       this.sweepRunning = false;
     }
+
     return { refreshed, errored, checked };
   }
 
-  // Scan all markdown files for the opt-in frontmatter property. Reads from
-  // Obsidian's metadata cache (already-parsed), so this is sub-millisecond
-  // even on large vaults.
   private discoverScheduledNotes(): Array<{
     file: TFile;
     cadence: Cadence;
@@ -455,10 +330,6 @@ export default class MotherDuckPlugin extends Plugin {
     return out;
   }
 
-  // Scan every markdown file's source for at least one duckdb/motherduck
-  // fence. Reads each file (slower than discoverScheduledNotes which uses the
-  // metadata cache) but only fires on the manual button, where a
-  // few-seconds-once-per-click cost is acceptable.
   private async discoverNotesWithBlocks(): Promise<TFile[]> {
     const out: TFile[] = [];
     for (const file of this.app.vault.getMarkdownFiles()) {
@@ -478,24 +349,6 @@ export default class MotherDuckPlugin extends Plugin {
     await this.saveSettings();
   }
 
-  private async withFileLock<T>(path: string, task: () => Promise<T>): Promise<T> {
-    const previous = this.fileLocks.get(path) ?? Promise.resolve();
-    let release!: () => void;
-    const gate = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    const next = previous.catch(() => undefined).then(() => gate);
-    this.fileLocks.set(path, next);
-    await previous.catch(() => undefined);
-
-    try {
-      return await task();
-    } finally {
-      release();
-      if (this.fileLocks.get(path) === next) this.fileLocks.delete(path);
-    }
-  }
-
   private async modifyIfUnchanged(file: TFile, baseContent: string, newContent: string): Promise<boolean> {
     if (newContent === baseContent) return false;
     const latest = await this.app.vault.read(file);
@@ -506,651 +359,5 @@ export default class MotherDuckPlugin extends Plugin {
     }
     await this.app.vault.modify(file, newContent);
     return true;
-  }
-
-  // ----------------- freeze / refresh -----------------
-
-  async refreshFile(path: string): Promise<string> {
-    const r = await this.refreshFileDetailed(path);
-    return `Refreshed ${r.refreshed} block(s), ${r.errored} error(s) in ${path}`;
-  }
-
-  async refreshFileDetailed(
-    path: string,
-  ): Promise<{ refreshed: number; errored: number; firstError?: string }> {
-    return this.withFileLock(path, async () => {
-      const file = this.app.vault.getAbstractFileByPath(path);
-      if (!(file instanceof TFile)) throw new Error(`not a file: ${path}`);
-      const content = await this.app.vault.read(file);
-      const result = await this.processAllBlocks(content);
-      await this.modifyIfUnchanged(file, content, result.newContent);
-      return { refreshed: result.refreshed, errored: result.errored, firstError: result.firstError };
-    });
-  }
-
-  async freezeAtCursor(file: TFile, cursorLine: number): Promise<string> {
-    return this.withFileLock(file.path, async () => {
-      const content = await this.app.vault.read(file);
-      const blocks = findBlocks(content);
-      const hit = blocks.find((b) => cursorLine >= b.startLine && cursorLine <= b.endLine);
-      if (!hit) throw new Error("no ```duckdb or ```motherduck block at cursor");
-      const newContent = await this.freezeBlock(content, hit);
-      await this.modifyIfUnchanged(file, content, newContent);
-      return `Froze 1 block`;
-    });
-  }
-
-  async processAllBlocks(
-    content: string,
-  ): Promise<{ newContent: string; refreshed: number; errored: number; firstError?: string }> {
-    const blocks = findBlocks(content);
-    let working = content;
-    let refreshed = 0;
-    let errored = 0;
-    let firstError: string | undefined;
-    // Process from last to first so line offsets stay valid as we mutate content
-    for (let i = blocks.length - 1; i >= 0; i--) {
-      try {
-        working = await this.freezeBlock(working, blocks[i]);
-        refreshed++;
-      } catch (e) {
-        console.error("[motherduck] block error", e);
-        errored++;
-        if (!firstError) firstError = e instanceof Error ? e.message : String(e);
-      }
-    }
-    return { newContent: working, refreshed, errored, firstError };
-  }
-
-  async freezeBlock(content: string, block: FencedBlock): Promise<string> {
-    const { rows, columns } = await this.runQuery(block.sql, block.connection);
-    const mdTable = renderMarkdownTable(
-      rows,
-      columns,
-      block.sql,
-      block.connection,
-      this.settings.rowCap,
-    );
-    return writeSentinelAfterBlock(content, block, mdTable);
-  }
-
-  // ----------------- reading-mode renderer -----------------
-
-  renderBlock(connection: Connection, src: string, el: HTMLElement, ctx: MarkdownPostProcessorContext) {
-    const sql = src.trim();
-    if (!sql) {
-      el.createEl("em", { text: connection === "cloud" ? "empty motherduck block" : "empty duckdb block" });
-      return;
-    }
-
-    const wrap = el.createDiv({ cls: "motherduck-block" });
-
-    // Connection badge above the SQL: tells the reader at a glance whether
-    // this block hits the local DuckDB or MotherDuck cloud, mapping 1:1 to
-    // the section names in plugin settings.
-    const badge = wrap.createDiv({ cls: "motherduck-block__badge" });
-    const iconWrap = badge.createDiv({ cls: "motherduck-block__engine-icon" });
-    iconWrap.innerHTML = connection === "cloud" ? MOTHERDUCK_ICON : DUCKDB_ICON;
-    if (connection === "cloud") {
-      badge.createEl("span", { text: "MotherDuck" });
-    } else {
-      badge.createEl("span", { text: "DuckDB " });
-      badge.createEl("code", { text: shortPathLabel(this.settings.dbPath) });
-    }
-
-    // Refresh-cadence dropdown, right-aligned in the badge row. Reads from and
-    // writes to the host note's `duckdb-motherduck-refresh` frontmatter so users
-    // don't have to learn the property name. Note-scoped, not block-scoped:
-    // changing it in one block updates the note's frontmatter and therefore
-    // every block in the note (other blocks pick up the change on next render).
-    this.attachRefreshDropdown(badge, ctx);
-
-    const pre = wrap.createEl("pre", { cls: "motherduck-block__sql" });
-    pre.createEl("code", { text: sql });
-
-    const btnRow = wrap.createDiv({ cls: "motherduck-block__controls" });
-
-    const runBtn = btnRow.createEl("button", { cls: "motherduck-block__button" });
-    setIcon(runBtn, "play");
-    runBtn.appendText("Run");
-    runBtn.title = "Run query";
-    runBtn.setAttr("aria-label", "Run query");
-
-    const freezeBtn = btnRow.createEl("button", { cls: "motherduck-block__button" });
-    setIcon(freezeBtn, "pin");
-    freezeBtn.appendText("Freeze");
-    freezeBtn.title = "Run and freeze result below this block";
-    freezeBtn.setAttr("aria-label", "Run and freeze result below this block");
-
-    const status = btnRow.createEl("span", { cls: "motherduck-block__status" });
-
-    const resultEl = wrap.createDiv({ cls: "motherduck-block__result" });
-
-    runBtn.addEventListener("click", async () => {
-      resultEl.empty();
-      status.setText("running…");
-      runBtn.setAttr("disabled", "true");
-      freezeBtn.setAttr("disabled", "true");
-      const t0 = performance.now();
-      try {
-        const { rows, columns } = await this.runQuery(sql, connection);
-        const dt = Math.round(performance.now() - t0);
-        status.setText(`${rows.length} row(s) · ${dt} ms`);
-        renderDomTable(resultEl, rows, columns, this.settings.rowCap);
-      } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        status.setText("error");
-        const errEl = resultEl.createEl("pre", { cls: "motherduck-block__error" });
-        errEl.setText(msg);
-      } finally {
-        runBtn.removeAttribute("disabled");
-        freezeBtn.removeAttribute("disabled");
-      }
-    });
-
-    freezeBtn.addEventListener("click", async () => {
-      status.setText("freezing…");
-      runBtn.setAttr("disabled", "true");
-      freezeBtn.setAttr("disabled", "true");
-      try {
-        const file = this.app.vault.getAbstractFileByPath(ctx.sourcePath);
-        if (!(file instanceof TFile)) throw new Error(`not a file: ${ctx.sourcePath}`);
-        await this.withFileLock(file.path, async () => {
-          const info = ctx.getSectionInfo(el);
-          if (!info) throw new Error("cannot locate block position");
-          const content = await this.app.vault.read(file);
-          const block =
-            findBlocks(content).find(
-              (candidate) =>
-                candidate.startLine === info.lineStart && candidate.endLine === info.lineEnd,
-            ) ?? { sql, startLine: info.lineStart, endLine: info.lineEnd, connection };
-          const newContent = await this.freezeBlock(content, block);
-          await this.modifyIfUnchanged(file, content, newContent);
-        });
-        status.setText("frozen ✓");
-      } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        status.setText(`error: ${msg}`);
-        console.error("[motherduck] freeze failed", e);
-      } finally {
-        runBtn.removeAttribute("disabled");
-        freezeBtn.removeAttribute("disabled");
-      }
-    });
-  }
-}
-
-// ----------------- helpers -----------------
-
-interface FencedBlock {
-  sql: string;
-  startLine: number; // line of opening ```
-  endLine: number; // line of closing ```
-  connection: Connection;
-}
-
-function findBlocks(content: string): FencedBlock[] {
-  const lines = content.split("\n");
-  const blocks: FencedBlock[] = [];
-  let i = 0;
-  while (i < lines.length) {
-    const open = lines[i].match(/^ {0,3}(`{3,}|~{3,})\s*(motherduck|duckdb)(?:\s+.*)?$/);
-    if (open) {
-      const fence = open[1];
-      const fenceChar = fence[0];
-      const closeRe = new RegExp(`^ {0,3}${escapeRegExp(fenceChar)}{${fence.length},}\\s*$`);
-      const connection: Connection = open[2] === "duckdb" ? "local" : "cloud";
-      const start = i;
-      i++;
-      const sqlLines: string[] = [];
-      while (i < lines.length && !closeRe.test(lines[i])) {
-        sqlLines.push(lines[i]);
-        i++;
-      }
-      if (i < lines.length) {
-        blocks.push({ sql: sqlLines.join("\n"), startLine: start, endLine: i, connection });
-        i++;
-      }
-    } else {
-      i++;
-    }
-  }
-  return blocks;
-}
-
-function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function writeSentinelAfterBlock(content: string, block: FencedBlock, mdTable: string): string {
-  const lines = content.split("\n");
-  const afterBlock = block.endLine + 1;
-  // Look ahead past optional blank line + existing sentinel block
-  let cutEnd = afterBlock;
-  // Skip blank lines between code block and potential sentinel
-  let j = afterBlock;
-  while (j < lines.length && lines[j].trim() === "") j++;
-  if (j < lines.length && /<!-- md:cache hash=/.test(lines[j])) {
-    // find matching end sentinel
-    let k = j;
-    while (k < lines.length && !/<!-- md:cache-end -->/.test(lines[k])) k++;
-    if (k < lines.length) cutEnd = k + 1;
-  }
-  const before = lines.slice(0, afterBlock).join("\n");
-  const rest = lines.slice(cutEnd).join("\n");
-  return before + "\n\n" + mdTable + (rest ? "\n\n" + rest : "\n");
-}
-
-// Short-form display of the configured local DB path: keeps `:memory:` as-is
-// and strips directory parts off real paths / URIs so the block badge stays
-// compact (e.g. `opfs://notes.duckdb` -> `notes.duckdb`).
-// True if a note's `lastRefresh` timestamp is older than its cadence interval,
-// or if it's missing/unparseable (treat as never-refreshed and therefore due).
-function isOverdue(cadence: Cadence, lastRefresh: string | null): boolean {
-  if (!lastRefresh) return true;
-  const last = Date.parse(lastRefresh);
-  if (Number.isNaN(last)) return true;
-  return Date.now() - last >= CADENCE_MS[cadence];
-}
-
-// Friendly local-time render of an ISO timestamp for the activity log.
-function formatLogTimestamp(iso: string): string {
-  try {
-    return new Date(iso).toLocaleString();
-  } catch {
-    return iso;
-  }
-}
-
-function shortPathLabel(rawPath: string): string {
-  const v = (rawPath || "").trim();
-  if (!v || v === ":memory:") return ":memory:";
-  const m = v.match(/[^/\\]+$/);
-  return m ? m[0] : v;
-}
-
-function simpleHash(s: string): string {
-  let h = 0;
-  for (let i = 0; i < s.length; i++) h = ((h << 5) - h + s.charCodeAt(i)) | 0;
-  return (h >>> 0).toString(16).padStart(8, "0");
-}
-
-function escapeCell(v: unknown): string {
-  if (v === null || v === undefined) return "";
-  const s = typeof v === "object" ? JSON.stringify(v) : String(v);
-  return s.replace(/\\/g, "\\\\").replace(/\|/g, "\\|").replace(/\n/g, " ").replace(/\r/g, "");
-}
-
-function renderMarkdownTable(
-  rows: Row[],
-  columns: string[],
-  sql: string,
-  connection: Connection,
-  rowCap: number,
-): string {
-  const hash = simpleHash(`${connection}\n${sql.trim()}`);
-  const ts = new Date().toISOString();
-  const totalRows = rows.length;
-  const cap = normalizedRowCap(rowCap);
-  const shown = rows.slice(0, cap);
-
-  const open = `<!-- md:cache hash=${hash} conn=${connection} ts=${ts} rows=${totalRows} -->`;
-  const close = `<!-- md:cache-end -->`;
-
-  if (columns.length === 0) {
-    return `${open}\n\n_(0 rows)_\n\n${close}`;
-  }
-  const header = "| " + columns.map(escapeCell).join(" | ") + " |";
-  const sep = "| " + columns.map(() => "---").join(" | ") + " |";
-  const body = shown.map((r) => "| " + columns.map((c) => escapeCell(r[c])).join(" | ") + " |");
-  const truncated =
-    totalRows > cap ? `\n\n> … ${totalRows - cap} more rows hidden (cap ${cap})` : "";
-  const emptyNotice = totalRows === 0 ? "\n\n> 0 rows" : "";
-  // Blank lines around the table + around the sentinel comments are required
-  // so markdown parsers don't fuse them into a single HTML block and skip table rendering.
-  return `${open}\n\n${header}\n${sep}\n${body.join("\n")}${emptyNotice}${truncated}\n\n${close}`;
-}
-
-function renderDomTable(parent: HTMLElement, rows: Row[], columns: string[], rowCap: number) {
-  if (columns.length === 0) {
-    parent.createEl("em", { text: "(0 rows)" });
-    return;
-  }
-  const cap = normalizedRowCap(rowCap);
-  const shown = rows.slice(0, cap);
-  const table = parent.createEl("table", { cls: "motherduck-result-table" });
-  const thead = table.createEl("thead").createEl("tr");
-  for (const c of columns) {
-    const th = thead.createEl("th", { text: c });
-  }
-  const tbody = table.createEl("tbody");
-  for (const row of shown) {
-    const tr = tbody.createEl("tr");
-    for (const c of columns) {
-      const td = tr.createEl("td");
-      const v = row[c];
-      td.setText(v === null || v === undefined ? "" : typeof v === "object" ? JSON.stringify(v) : String(v));
-    }
-  }
-  if (rows.length === 0) {
-    const empty = parent.createEl("div", { cls: "motherduck-muted", text: "0 rows" });
-    empty.style.marginTop = "4px";
-  }
-  if (rows.length > cap) {
-    const more = parent.createEl("div", {
-      cls: "motherduck-muted",
-      text: `… ${rows.length - cap} more rows hidden (cap ${cap})`,
-    });
-    more.style.marginTop = "4px";
-  }
-}
-
-function normalizedRowCap(rowCap: number): number {
-  return Number.isFinite(rowCap) && rowCap > 0
-    ? Math.min(Math.floor(rowCap), 10000)
-    : DEFAULTS.rowCap;
-}
-
-// ----------------- settings tab -----------------
-
-class SettingsTab extends PluginSettingTab {
-  plugin: MotherDuckPlugin;
-  constructor(app: App, plugin: MotherDuckPlugin) {
-    super(app, plugin);
-    this.plugin = plugin;
-  }
-  display(): void {
-    this.containerEl.empty();
-
-    const intro = this.containerEl.createEl("p", { cls: "setting-item-description" });
-    intro.setText(
-      "Run SQL in your notes against a local DuckDB file or your MotherDuck workspace. " +
-        "Results render live, and can be frozen as inline markdown tables, either per-block via the Freeze button or in bulk via the 'Refresh all queries' command.",
-    );
-
-    renderSectionHeader(this.containerEl, DUCKDB_ICON, "DuckDB", {
-      text: "Used by ```duckdb code blocks. ",
-      linkText: "duckdb.org",
-      href: "https://duckdb.org",
-    });
-
-    new Setting(this.containerEl)
-      .setName("Path to local DuckDB file")
-      .setDesc(
-        createFragment((frag) => {
-          frag.appendText("Default ");
-          frag.createEl("code", { text: ":memory:" });
-          frag.appendText(
-            " is an ephemeral in-memory database. Or paste an absolute path to query an existing on-disk file (read-only, writes don't persist back). Examples: ",
-          );
-          frag.createEl("code", { text: "/Users/you/data.duckdb" });
-          frag.appendText(", ");
-          frag.createEl("code", { text: "/home/you/data.duckdb" });
-          frag.appendText(", ");
-          frag.createEl("code", { text: "C:\\Users\\you\\data.duckdb" });
-          frag.appendText(".");
-        }),
-      )
-      .addText((t) =>
-        t
-          .setPlaceholder(":memory:")
-          .setValue(this.plugin.settings.dbPath)
-          .onChange(async (v) => {
-            this.plugin.settings.dbPath = v.trim() || ":memory:";
-            await this.plugin.saveSettings();
-            await this.plugin.resetRuntimes("local");
-          }),
-      );
-
-    new Setting(this.containerEl)
-      .setName("Test DuckDB connection")
-      .setDesc("Runs a tiny local query using the current DuckDB setting.")
-      .addButton((b) =>
-        b.setButtonText("Test").onClick(async () => {
-          b.setDisabled(true);
-          b.setButtonText("Testing...");
-          try {
-            const result = await this.plugin.runQuery("SELECT 42 AS ok", "local");
-            new Notice(`DuckDB ok (${result.rows.length} row)`);
-          } catch (e) {
-            const msg = e instanceof Error ? e.message : String(e);
-            new Notice(`DuckDB error: ${msg}`);
-          } finally {
-            b.setDisabled(false);
-            b.setButtonText("Test");
-          }
-        }),
-      );
-
-    renderSectionHeader(this.containerEl, MOTHERDUCK_ICON, "MotherDuck", {
-      text: "Used by ```motherduck code blocks. ",
-      linkText: "motherduck.com",
-      href: "https://motherduck.com",
-    });
-
-    new Setting(this.containerEl)
-      .setName("MotherDuck token")
-      .setDesc(
-        createFragment((frag) => {
-          frag.appendText(
-            "Paste a MotherDuck access token to query the cloud instead of local DuckDB. Stored unencrypted in ",
-          );
-          frag.createEl("code", { text: "data.json" });
-          frag.appendText(" inside this vault's plugin folder; if you sync this vault publicly, unset the token first.");
-          frag.createEl("br");
-          frag.createEl("br");
-          frag.appendText("Get a token: prefer a ");
-          const sa = frag.createEl("a", {
-            href: "https://motherduck.com/docs/key-tasks/service-accounts-guide/create-and-configure-service-accounts/",
-            text: "service account token",
-          });
-          sa.setAttr("target", "_blank");
-          sa.setAttr("rel", "noopener noreferrer");
-          frag.appendText(" (scoped permissions, individually revocable) or use a ");
-          const pat = frag.createEl("a", {
-            href: "https://motherduck.com/docs/key-tasks/authenticating-and-connecting-to-motherduck/authenticating-to-motherduck/#authentication-using-an-access-token",
-            text: "personal access token",
-          });
-          pat.setAttr("target", "_blank");
-          pat.setAttr("rel", "noopener noreferrer");
-          frag.appendText(".");
-        }),
-      )
-      .addText((t) => {
-        t.inputEl.type = "password";
-        t.inputEl.autocomplete = "off";
-        t.setPlaceholder("eyJ... (leave empty for local DuckDB)")
-          .setValue(this.plugin.settings.mdToken)
-          .onChange(async (v) => {
-            this.plugin.settings.mdToken = v.trim();
-            await this.plugin.saveSettings();
-            await this.plugin.resetRuntimes("cloud");
-          });
-      });
-
-    new Setting(this.containerEl)
-      .setName("Test MotherDuck connection")
-      .setDesc("Runs a tiny cloud query using the current token.")
-      .addButton((b) =>
-        b.setButtonText("Test").onClick(async () => {
-          b.setDisabled(true);
-          b.setButtonText("Testing...");
-          try {
-            const result = await this.plugin.runQuery("SELECT 42 AS ok", "cloud");
-            new Notice(`MotherDuck ok (${result.rows.length} row)`);
-          } catch (e) {
-            const msg = e instanceof Error ? e.message : String(e);
-            new Notice(`MotherDuck error: ${msg}`);
-          } finally {
-            b.setDisabled(false);
-            b.setButtonText("Test");
-          }
-        }),
-      );
-
-    this.containerEl.createEl("h3", { text: "Scheduled refresh" });
-
-    const scheduleDesc = this.containerEl.createEl("p", { cls: "setting-item-description" });
-    scheduleDesc.appendText("Pick a cadence in the ");
-    scheduleDesc.createEl("code", { text: "Refresh" });
-    scheduleDesc.appendText(" dropdown above any SQL block to opt that note in. The plugin writes ");
-    scheduleDesc.createEl("code", { text: "duckdb-motherduck-refresh" });
-    scheduleDesc.appendText(
-      " to the note's frontmatter, sweeps once an hour while Obsidian is running, and refreshes overdue notes. The active editor is skipped to avoid stomping in-progress edits.",
-    );
-
-    new Setting(this.containerEl)
-      .setName("Auto-refresh scheduled notes")
-      .setDesc("When on, opted-in notes refresh automatically based on their cadence.")
-      .addToggle((t) =>
-        t.setValue(this.plugin.settings.scheduleEnabled).onChange(async (v) => {
-          this.plugin.settings.scheduleEnabled = v;
-          await this.plugin.saveSettings();
-          if (v) this.plugin.startScheduler();
-          else this.plugin.stopScheduler();
-        }),
-      );
-
-    new Setting(this.containerEl)
-      .setName("Refresh all notes with queries now")
-      .setDesc("Sweeps every note in the vault that has a SQL block, ignoring cadence and frontmatter opt-in. Available even when auto-refresh is off.")
-      .addButton((b) =>
-        b.setButtonText("Refresh now").onClick(async () => {
-          b.setDisabled(true);
-          b.setButtonText("Refreshing...");
-          try {
-            const r = await this.plugin.runManualSweep();
-            new Notice(
-              `Refreshed ${r.refreshed} note(s), ${r.errored} error(s), ${r.checked} scanned`,
-            );
-          } catch (e) {
-            const msg = e instanceof Error ? e.message : String(e);
-            new Notice(`error: ${msg}`);
-          } finally {
-            b.setDisabled(false);
-            b.setButtonText("Refresh now");
-            this.display(); // re-render so the new log entries show up
-          }
-        }),
-      );
-
-    const logTitle = this.containerEl.createEl("h4", { text: "Activity log" });
-    logTitle.style.marginTop = "16px";
-    logTitle.style.marginBottom = "4px";
-
-    if (this.plugin.settings.refreshLog.length === 0) {
-      const empty = this.containerEl.createEl("p", { cls: "setting-item-description" });
-      empty.setText("No refreshes recorded yet.");
-    } else {
-      const logEl = this.containerEl.createDiv();
-      logEl.style.maxHeight = "300px";
-      logEl.style.overflowY = "auto";
-      logEl.style.border = "1px solid var(--background-modifier-border)";
-      logEl.style.borderRadius = "6px";
-      logEl.style.padding = "8px";
-      logEl.style.fontSize = "0.85em";
-      logEl.style.fontFamily = "var(--font-monospace)";
-      logEl.style.lineHeight = "1.5";
-
-      for (const entry of this.plugin.settings.refreshLog.slice(0, 30)) {
-        const row = logEl.createDiv();
-        const ts = row.createEl("span", { text: formatLogTimestamp(entry.ts) });
-        ts.style.opacity = "0.7";
-        row.appendText("  ");
-        const trigger = row.createEl("span", { text: entry.trigger });
-        trigger.style.opacity = "0.7";
-        row.appendText("  ");
-
-        const linkEl = row.createEl("a", { text: entry.path });
-        linkEl.style.cursor = "pointer";
-        linkEl.addEventListener("click", (e) => {
-          e.preventDefault();
-          const f = this.plugin.app.vault.getAbstractFileByPath(entry.path);
-          if (f instanceof TFile) {
-            this.plugin.app.workspace.getLeaf().openFile(f);
-          }
-        });
-
-        // Three shapes:
-        //   no errors       -> "N refreshed"
-        //   per-block errors -> "N refreshed, M errored: <first message>"
-        //   refresh threw   -> "error: <message>"
-        if (entry.blocks === 0 && entry.errored === 0 && entry.errorMessage) {
-          row.appendText("  ");
-          const err = row.createEl("span", { text: `error: ${entry.errorMessage}` });
-          err.style.color = "var(--text-error)";
-        } else {
-          row.appendText(`  ${entry.blocks} refreshed`);
-          if (entry.errored > 0) {
-            const err = row.createEl("span", {
-              text: entry.errorMessage
-                ? `, ${entry.errored} errored: ${entry.errorMessage}`
-                : `, ${entry.errored} errored`,
-            });
-            err.style.color = "var(--text-error)";
-          }
-        }
-      }
-
-      new Setting(this.containerEl).addButton((b) =>
-        b.setButtonText("Clear log").onClick(async () => {
-          this.plugin.settings.refreshLog = [];
-          await this.plugin.saveSettings();
-          this.display();
-        }),
-      );
-    }
-
-    this.containerEl.createEl("h3", { text: "General" });
-
-    new Setting(this.containerEl)
-      .setName("Row cap")
-      .setDesc("Max rows rendered inline / frozen. Truncation notice appended if exceeded.")
-      .addText((t) =>
-        t
-          .setPlaceholder("100")
-          .setValue(String(this.plugin.settings.rowCap))
-          .onChange(async (v) => {
-            const n = parseInt(v, 10);
-            if (!Number.isNaN(n) && n > 0) {
-              this.plugin.settings.rowCap = Math.min(Math.floor(n), 10000);
-              await this.plugin.saveSettings();
-            }
-          }),
-      );
-  }
-}
-
-function renderSectionHeader(
-  parent: HTMLElement,
-  svgMarkup: string,
-  title: string,
-  tagline?: { text: string; linkText: string; href: string },
-) {
-  const row = parent.createDiv();
-  row.style.display = "flex";
-  row.style.alignItems = "center";
-  row.style.gap = "10px";
-  row.style.marginTop = "24px";
-  row.style.marginBottom = tagline ? "4px" : "8px";
-  row.style.paddingBottom = "6px";
-  row.style.borderBottom = "1px solid var(--background-modifier-border)";
-
-  const iconWrap = row.createDiv();
-  iconWrap.style.display = "flex";
-  iconWrap.style.alignItems = "center";
-  iconWrap.innerHTML = svgMarkup;
-
-  const h = row.createEl("h3", { text: title });
-  h.style.margin = "0";
-
-  if (tagline) {
-    const desc = parent.createEl("p", { cls: "setting-item-description" });
-    desc.style.marginTop = "0";
-    desc.style.marginBottom = "8px";
-    desc.appendText(tagline.text);
-    const a = desc.createEl("a", { href: tagline.href, text: tagline.linkText });
-    a.setAttr("target", "_blank");
-    a.setAttr("rel", "noopener noreferrer");
   }
 }

--- a/main.ts
+++ b/main.ts
@@ -58,9 +58,21 @@ export default class MotherDuckPlugin extends Plugin {
   // cloud one. Queries on different connections in the same note coexist.
   private localRuntime: Runtime | null = null;
   private cloudRuntime: Runtime | null = null;
+  private localRuntimePromise: Promise<Runtime> | null = null;
+  private cloudRuntimePromise: Promise<Runtime> | null = null;
+  private runtimeGeneration: Record<Connection, number> = {
+    local: 0,
+    cloud: 0,
+  };
+  private queryQueues: Record<Connection, Promise<unknown>> = {
+    local: Promise.resolve(),
+    cloud: Promise.resolve(),
+  };
+  private fileLocks = new Map<string, Promise<void>>();
   // Scheduler state. `sweepInterval` is the setInterval ID (or null when the
   // scheduler is off); `sweepRunning` prevents overlapping sweeps if a previous
   // one is still working when the next interval fires.
+  private sweepTimeout: number | null = null;
   private sweepInterval: number | null = null;
   private sweepRunning = false;
   api!: {
@@ -138,6 +150,9 @@ export default class MotherDuckPlugin extends Plugin {
 
   async resetRuntimes(only?: Connection) {
     if (!only || only === "local") {
+      this.runtimeGeneration.local++;
+      this.localRuntimePromise = null;
+      this.queryQueues.local = Promise.resolve();
       try {
         await this.localRuntime?.close();
       } catch (e) {
@@ -146,6 +161,9 @@ export default class MotherDuckPlugin extends Plugin {
       this.localRuntime = null;
     }
     if (!only || only === "cloud") {
+      this.runtimeGeneration.cloud++;
+      this.cloudRuntimePromise = null;
+      this.queryQueues.cloud = Promise.resolve();
       try {
         await this.cloudRuntime?.close();
       } catch (e) {
@@ -171,19 +189,70 @@ export default class MotherDuckPlugin extends Plugin {
         throw new Error("MotherDuck token not set. Configure it in plugin settings.");
       }
       if (this.cloudRuntime) return this.cloudRuntime;
-      this.cloudRuntime = new MotherDuckRuntime(this.settings.mdToken);
-      await this.cloudRuntime.init();
-      return this.cloudRuntime;
+      if (!this.cloudRuntimePromise) {
+        const rt = new MotherDuckRuntime(this.settings.mdToken);
+        const generation = this.runtimeGeneration.cloud;
+        this.cloudRuntimePromise = rt
+          .init()
+          .then(() => {
+            if (this.runtimeGeneration.cloud !== generation) {
+              void rt.close();
+              throw new Error("MotherDuck connection reset while initializing. Retry the query.");
+            }
+            this.cloudRuntime = rt;
+            return rt;
+          })
+          .catch(async (e) => {
+            await rt.close().catch((closeError) => {
+              console.error("[motherduck] close failed after cloud init error", closeError);
+            });
+            throw e;
+          })
+          .finally(() => {
+            this.cloudRuntimePromise = null;
+          });
+      }
+      return this.cloudRuntimePromise;
     }
     if (this.localRuntime) return this.localRuntime;
-    this.localRuntime = new DuckDBWasmRuntime(this.settings.dbPath);
-    await this.localRuntime.init();
-    return this.localRuntime;
+    if (!this.localRuntimePromise) {
+      const rt = new DuckDBWasmRuntime(this.settings.dbPath);
+      const generation = this.runtimeGeneration.local;
+      this.localRuntimePromise = rt
+        .init()
+          .then(() => {
+            if (this.runtimeGeneration.local !== generation) {
+              void rt.close();
+              throw new Error("DuckDB connection reset while initializing. Retry the query.");
+            }
+            this.localRuntime = rt;
+            return rt;
+          })
+          .catch(async (e) => {
+            await rt.close().catch((closeError) => {
+              console.error("[motherduck] close failed after local init error", closeError);
+            });
+            throw e;
+          })
+          .finally(() => {
+            this.localRuntimePromise = null;
+          });
+    }
+    return this.localRuntimePromise;
   }
 
   async runQuery(sql: string, connection: Connection): Promise<{ rows: Row[]; columns: string[] }> {
-    const rt = await this.getRuntime(connection);
-    return rt.runQuery(sql);
+    return this.enqueueQuery(connection, async () => {
+      const rt = await this.getRuntime(connection);
+      return rt.runQuery(sql);
+    });
+  }
+
+  private enqueueQuery<T>(connection: Connection, op: () => Promise<T>): Promise<T> {
+    const previous = this.queryQueues[connection].catch(() => undefined);
+    const next = previous.then(op);
+    this.queryQueues[connection] = next.catch(() => undefined);
+    return next;
   }
 
   // Append a small <select> to the given parent, mapped to the host note's
@@ -198,25 +267,14 @@ export default class MotherDuckPlugin extends Plugin {
     // Group the icon + dropdown together and right-align as a unit, so the
     // icon is visually attached to the select rather than floating between
     // the badge label and the picker.
-    const group = parent.createDiv();
-    group.style.marginLeft = "auto";
-    group.style.display = "flex";
-    group.style.alignItems = "center";
-    group.style.gap = "4px";
+    const group = parent.createDiv({ cls: "motherduck-refresh-control" });
 
-    const iconHost = group.createDiv();
-    iconHost.style.display = "flex";
-    iconHost.style.alignItems = "center";
+    const iconHost = group.createDiv({ cls: "motherduck-refresh-control__icon" });
     setIcon(iconHost, "refresh-cw");
-    const refreshSvg = iconHost.querySelector("svg");
-    if (refreshSvg) {
-      refreshSvg.setAttribute("width", "12");
-      refreshSvg.setAttribute("height", "12");
-    }
 
-    const select = group.createEl("select") as HTMLSelectElement;
-    select.style.fontSize = "0.85em";
+    const select = group.createEl("select", { cls: "motherduck-refresh-control__select" }) as HTMLSelectElement;
     select.title = "Auto-refresh this note (writes to its frontmatter)";
+    select.setAttr("aria-label", "Auto-refresh this note");
 
     const opts: Array<{ value: "" | Cadence; label: string }> = [
       { value: "", label: "Refresh: none" },
@@ -254,18 +312,25 @@ export default class MotherDuckPlugin extends Plugin {
   // ----------------- scheduler -----------------
 
   startScheduler() {
-    if (this.sweepInterval !== null) return;
+    if (this.sweepInterval !== null || this.sweepTimeout !== null) return;
     // Initial post-load sweep, after a short delay to let Obsidian finish booting.
-    window.setTimeout(() => {
-      void this.runScheduledSweep();
+    this.sweepTimeout = window.setTimeout(() => {
+      this.sweepTimeout = null;
+      if (this.settings.scheduleEnabled) void this.runScheduledSweep();
     }, STARTUP_DELAY_MS);
     // Then sweep at the regular interval.
-    this.sweepInterval = window.setInterval(() => {
-      void this.runScheduledSweep();
-    }, SWEEP_INTERVAL_MS);
+    this.sweepInterval = this.registerInterval(
+      window.setInterval(() => {
+        if (this.settings.scheduleEnabled) void this.runScheduledSweep();
+      }, SWEEP_INTERVAL_MS),
+    );
   }
 
   stopScheduler() {
+    if (this.sweepTimeout !== null) {
+      window.clearTimeout(this.sweepTimeout);
+      this.sweepTimeout = null;
+    }
     if (this.sweepInterval !== null) {
       window.clearInterval(this.sweepInterval);
       this.sweepInterval = null;
@@ -397,8 +462,8 @@ export default class MotherDuckPlugin extends Plugin {
   private async discoverNotesWithBlocks(): Promise<TFile[]> {
     const out: TFile[] = [];
     for (const file of this.app.vault.getMarkdownFiles()) {
-      const content = await this.app.vault.read(file);
-      if (/^```(motherduck|duckdb)\s*$/m.test(content)) {
+      const content = await this.app.vault.cachedRead(file);
+      if (findBlocks(content).length > 0) {
         out.push(file);
       }
     }
@@ -413,6 +478,36 @@ export default class MotherDuckPlugin extends Plugin {
     await this.saveSettings();
   }
 
+  private async withFileLock<T>(path: string, task: () => Promise<T>): Promise<T> {
+    const previous = this.fileLocks.get(path) ?? Promise.resolve();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const next = previous.catch(() => undefined).then(() => gate);
+    this.fileLocks.set(path, next);
+    await previous.catch(() => undefined);
+
+    try {
+      return await task();
+    } finally {
+      release();
+      if (this.fileLocks.get(path) === next) this.fileLocks.delete(path);
+    }
+  }
+
+  private async modifyIfUnchanged(file: TFile, baseContent: string, newContent: string): Promise<boolean> {
+    if (newContent === baseContent) return false;
+    const latest = await this.app.vault.read(file);
+    if (latest !== baseContent) {
+      throw new Error(
+        `${file.path} changed while queries were running; not overwriting newer edits. Retry the refresh.`,
+      );
+    }
+    await this.app.vault.modify(file, newContent);
+    return true;
+  }
+
   // ----------------- freeze / refresh -----------------
 
   async refreshFile(path: string): Promise<string> {
@@ -423,24 +518,26 @@ export default class MotherDuckPlugin extends Plugin {
   async refreshFileDetailed(
     path: string,
   ): Promise<{ refreshed: number; errored: number; firstError?: string }> {
-    const file = this.app.vault.getAbstractFileByPath(path);
-    if (!(file instanceof TFile)) throw new Error(`not a file: ${path}`);
-    const content = await this.app.vault.read(file);
-    const result = await this.processAllBlocks(content);
-    if (result.newContent !== content) {
-      await this.app.vault.modify(file, result.newContent);
-    }
-    return { refreshed: result.refreshed, errored: result.errored, firstError: result.firstError };
+    return this.withFileLock(path, async () => {
+      const file = this.app.vault.getAbstractFileByPath(path);
+      if (!(file instanceof TFile)) throw new Error(`not a file: ${path}`);
+      const content = await this.app.vault.read(file);
+      const result = await this.processAllBlocks(content);
+      await this.modifyIfUnchanged(file, content, result.newContent);
+      return { refreshed: result.refreshed, errored: result.errored, firstError: result.firstError };
+    });
   }
 
   async freezeAtCursor(file: TFile, cursorLine: number): Promise<string> {
-    const content = await this.app.vault.read(file);
-    const blocks = findBlocks(content);
-    const hit = blocks.find((b) => cursorLine >= b.startLine && cursorLine <= b.endLine);
-    if (!hit) throw new Error("no ```duckdb or ```motherduck block at cursor");
-    const newContent = await this.freezeBlock(content, hit);
-    if (newContent !== content) await this.app.vault.modify(file, newContent);
-    return `Froze 1 block`;
+    return this.withFileLock(file.path, async () => {
+      const content = await this.app.vault.read(file);
+      const blocks = findBlocks(content);
+      const hit = blocks.find((b) => cursorLine >= b.startLine && cursorLine <= b.endLine);
+      if (!hit) throw new Error("no ```duckdb or ```motherduck block at cursor");
+      const newContent = await this.freezeBlock(content, hit);
+      await this.modifyIfUnchanged(file, content, newContent);
+      return `Froze 1 block`;
+    });
   }
 
   async processAllBlocks(
@@ -467,7 +564,13 @@ export default class MotherDuckPlugin extends Plugin {
 
   async freezeBlock(content: string, block: FencedBlock): Promise<string> {
     const { rows, columns } = await this.runQuery(block.sql, block.connection);
-    const mdTable = renderMarkdownTable(rows, columns, block.sql, this.settings.rowCap);
+    const mdTable = renderMarkdownTable(
+      rows,
+      columns,
+      block.sql,
+      block.connection,
+      this.settings.rowCap,
+    );
     return writeSentinelAfterBlock(content, block, mdTable);
   }
 
@@ -481,30 +584,13 @@ export default class MotherDuckPlugin extends Plugin {
     }
 
     const wrap = el.createDiv({ cls: "motherduck-block" });
-    wrap.style.border = "1px solid var(--background-modifier-border)";
-    wrap.style.borderRadius = "6px";
-    wrap.style.padding = "10px";
-    wrap.style.margin = "8px 0";
 
     // Connection badge above the SQL: tells the reader at a glance whether
     // this block hits the local DuckDB or MotherDuck cloud, mapping 1:1 to
     // the section names in plugin settings.
-    const badge = wrap.createDiv();
-    badge.style.display = "flex";
-    badge.style.alignItems = "center";
-    badge.style.gap = "6px";
-    badge.style.fontSize = "0.8em";
-    badge.style.opacity = "0.75";
-    badge.style.marginBottom = "6px";
-    const iconWrap = badge.createDiv();
-    iconWrap.style.display = "flex";
-    iconWrap.style.alignItems = "center";
+    const badge = wrap.createDiv({ cls: "motherduck-block__badge" });
+    const iconWrap = badge.createDiv({ cls: "motherduck-block__engine-icon" });
     iconWrap.innerHTML = connection === "cloud" ? MOTHERDUCK_ICON : DUCKDB_ICON;
-    const svg = iconWrap.querySelector("svg");
-    if (svg) {
-      svg.setAttribute("width", "14");
-      svg.setAttribute("height", "14");
-    }
     if (connection === "cloud") {
       badge.createEl("span", { text: "MotherDuck" });
     } else {
@@ -519,30 +605,32 @@ export default class MotherDuckPlugin extends Plugin {
     // every block in the note (other blocks pick up the change on next render).
     this.attachRefreshDropdown(badge, ctx);
 
-    const pre = wrap.createEl("pre");
-    pre.style.margin = "0 0 8px 0";
-    pre.style.fontSize = "0.85em";
+    const pre = wrap.createEl("pre", { cls: "motherduck-block__sql" });
     pre.createEl("code", { text: sql });
 
-    const btnRow = wrap.createDiv();
-    btnRow.style.display = "flex";
-    btnRow.style.gap = "8px";
-    btnRow.style.alignItems = "center";
+    const btnRow = wrap.createDiv({ cls: "motherduck-block__controls" });
 
-    const runBtn = btnRow.createEl("button", { text: "▶ Run" });
-    const freezeBtn = btnRow.createEl("button", { text: "📌 Freeze" });
-    const status = btnRow.createEl("span");
-    status.style.fontSize = "0.85em";
-    status.style.opacity = "0.7";
+    const runBtn = btnRow.createEl("button", { cls: "motherduck-block__button" });
+    setIcon(runBtn, "play");
+    runBtn.appendText("Run");
+    runBtn.title = "Run query";
+    runBtn.setAttr("aria-label", "Run query");
 
-    const resultEl = wrap.createDiv();
-    resultEl.style.marginTop = "8px";
-    resultEl.style.overflowX = "auto";
+    const freezeBtn = btnRow.createEl("button", { cls: "motherduck-block__button" });
+    setIcon(freezeBtn, "pin");
+    freezeBtn.appendText("Freeze");
+    freezeBtn.title = "Run and freeze result below this block";
+    freezeBtn.setAttr("aria-label", "Run and freeze result below this block");
+
+    const status = btnRow.createEl("span", { cls: "motherduck-block__status" });
+
+    const resultEl = wrap.createDiv({ cls: "motherduck-block__result" });
 
     runBtn.addEventListener("click", async () => {
       resultEl.empty();
       status.setText("running…");
       runBtn.setAttr("disabled", "true");
+      freezeBtn.setAttr("disabled", "true");
       const t0 = performance.now();
       try {
         const { rows, columns } = await this.runQuery(sql, connection);
@@ -552,33 +640,40 @@ export default class MotherDuckPlugin extends Plugin {
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
         status.setText("error");
-        const errEl = resultEl.createEl("pre");
-        errEl.style.color = "var(--text-error)";
-        errEl.style.whiteSpace = "pre-wrap";
+        const errEl = resultEl.createEl("pre", { cls: "motherduck-block__error" });
         errEl.setText(msg);
       } finally {
         runBtn.removeAttribute("disabled");
+        freezeBtn.removeAttribute("disabled");
       }
     });
 
     freezeBtn.addEventListener("click", async () => {
       status.setText("freezing…");
+      runBtn.setAttr("disabled", "true");
       freezeBtn.setAttr("disabled", "true");
       try {
-        const file = this.app.workspace.getActiveFile();
-        if (!file) throw new Error("no active file");
-        const info = ctx.getSectionInfo(el);
-        if (!info) throw new Error("cannot locate block position");
-        const content = await this.app.vault.read(file);
-        const block: FencedBlock = { sql, startLine: info.lineStart, endLine: info.lineEnd, connection };
-        const newContent = await this.freezeBlock(content, block);
-        if (newContent !== content) await this.app.vault.modify(file, newContent);
+        const file = this.app.vault.getAbstractFileByPath(ctx.sourcePath);
+        if (!(file instanceof TFile)) throw new Error(`not a file: ${ctx.sourcePath}`);
+        await this.withFileLock(file.path, async () => {
+          const info = ctx.getSectionInfo(el);
+          if (!info) throw new Error("cannot locate block position");
+          const content = await this.app.vault.read(file);
+          const block =
+            findBlocks(content).find(
+              (candidate) =>
+                candidate.startLine === info.lineStart && candidate.endLine === info.lineEnd,
+            ) ?? { sql, startLine: info.lineStart, endLine: info.lineEnd, connection };
+          const newContent = await this.freezeBlock(content, block);
+          await this.modifyIfUnchanged(file, content, newContent);
+        });
         status.setText("frozen ✓");
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
         status.setText(`error: ${msg}`);
         console.error("[motherduck] freeze failed", e);
       } finally {
+        runBtn.removeAttribute("disabled");
         freezeBtn.removeAttribute("disabled");
       }
     });
@@ -599,13 +694,16 @@ function findBlocks(content: string): FencedBlock[] {
   const blocks: FencedBlock[] = [];
   let i = 0;
   while (i < lines.length) {
-    const open = lines[i].match(/^```(motherduck|duckdb)\s*$/);
+    const open = lines[i].match(/^ {0,3}(`{3,}|~{3,})\s*(motherduck|duckdb)(?:\s+.*)?$/);
     if (open) {
-      const connection: Connection = open[1] === "duckdb" ? "local" : "cloud";
+      const fence = open[1];
+      const fenceChar = fence[0];
+      const closeRe = new RegExp(`^ {0,3}${escapeRegExp(fenceChar)}{${fence.length},}\\s*$`);
+      const connection: Connection = open[2] === "duckdb" ? "local" : "cloud";
       const start = i;
       i++;
       const sqlLines: string[] = [];
-      while (i < lines.length && !/^```\s*$/.test(lines[i])) {
+      while (i < lines.length && !closeRe.test(lines[i])) {
         sqlLines.push(lines[i]);
         i++;
       }
@@ -618,6 +716,10 @@ function findBlocks(content: string): FencedBlock[] {
     }
   }
   return blocks;
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function writeSentinelAfterBlock(content: string, block: FencedBlock, mdTable: string): string {
@@ -679,63 +781,74 @@ function escapeCell(v: unknown): string {
   return s.replace(/\\/g, "\\\\").replace(/\|/g, "\\|").replace(/\n/g, " ").replace(/\r/g, "");
 }
 
-function renderMarkdownTable(rows: Row[], columns: string[], sql: string, rowCap: number): string {
-  const hash = simpleHash(sql.trim());
+function renderMarkdownTable(
+  rows: Row[],
+  columns: string[],
+  sql: string,
+  connection: Connection,
+  rowCap: number,
+): string {
+  const hash = simpleHash(`${connection}\n${sql.trim()}`);
   const ts = new Date().toISOString();
   const totalRows = rows.length;
-  const shown = rows.slice(0, rowCap);
+  const cap = normalizedRowCap(rowCap);
+  const shown = rows.slice(0, cap);
 
-  const open = `<!-- md:cache hash=${hash} ts=${ts} rows=${totalRows} -->`;
+  const open = `<!-- md:cache hash=${hash} conn=${connection} ts=${ts} rows=${totalRows} -->`;
   const close = `<!-- md:cache-end -->`;
 
-  if (totalRows === 0 || columns.length === 0) {
+  if (columns.length === 0) {
     return `${open}\n\n_(0 rows)_\n\n${close}`;
   }
-  const header = "| " + columns.join(" | ") + " |";
+  const header = "| " + columns.map(escapeCell).join(" | ") + " |";
   const sep = "| " + columns.map(() => "---").join(" | ") + " |";
   const body = shown.map((r) => "| " + columns.map((c) => escapeCell(r[c])).join(" | ") + " |");
   const truncated =
-    totalRows > rowCap ? `\n\n> … ${totalRows - rowCap} more rows hidden (cap ${rowCap})` : "";
+    totalRows > cap ? `\n\n> … ${totalRows - cap} more rows hidden (cap ${cap})` : "";
+  const emptyNotice = totalRows === 0 ? "\n\n> 0 rows" : "";
   // Blank lines around the table + around the sentinel comments are required
   // so markdown parsers don't fuse them into a single HTML block and skip table rendering.
-  return `${open}\n\n${header}\n${sep}\n${body.join("\n")}${truncated}\n\n${close}`;
+  return `${open}\n\n${header}\n${sep}\n${body.join("\n")}${emptyNotice}${truncated}\n\n${close}`;
 }
 
 function renderDomTable(parent: HTMLElement, rows: Row[], columns: string[], rowCap: number) {
-  if (rows.length === 0) {
+  if (columns.length === 0) {
     parent.createEl("em", { text: "(0 rows)" });
     return;
   }
-  const shown = rows.slice(0, rowCap);
-  const table = parent.createEl("table");
-  table.style.borderCollapse = "collapse";
-  table.style.fontSize = "0.85em";
+  const cap = normalizedRowCap(rowCap);
+  const shown = rows.slice(0, cap);
+  const table = parent.createEl("table", { cls: "motherduck-result-table" });
   const thead = table.createEl("thead").createEl("tr");
   for (const c of columns) {
     const th = thead.createEl("th", { text: c });
-    th.style.borderBottom = "1px solid var(--background-modifier-border)";
-    th.style.padding = "4px 8px";
-    th.style.textAlign = "left";
   }
   const tbody = table.createEl("tbody");
   for (const row of shown) {
     const tr = tbody.createEl("tr");
     for (const c of columns) {
       const td = tr.createEl("td");
-      td.style.borderBottom = "1px solid var(--background-modifier-border)";
-      td.style.padding = "4px 8px";
       const v = row[c];
       td.setText(v === null || v === undefined ? "" : typeof v === "object" ? JSON.stringify(v) : String(v));
     }
   }
-  if (rows.length > rowCap) {
+  if (rows.length === 0) {
+    const empty = parent.createEl("div", { cls: "motherduck-muted", text: "0 rows" });
+    empty.style.marginTop = "4px";
+  }
+  if (rows.length > cap) {
     const more = parent.createEl("div", {
-      text: `… ${rows.length - rowCap} more rows hidden (cap ${rowCap})`,
+      cls: "motherduck-muted",
+      text: `… ${rows.length - cap} more rows hidden (cap ${cap})`,
     });
-    more.style.opacity = "0.7";
-    more.style.fontSize = "0.85em";
     more.style.marginTop = "4px";
   }
+}
+
+function normalizedRowCap(rowCap: number): number {
+  return Number.isFinite(rowCap) && rowCap > 0
+    ? Math.min(Math.floor(rowCap), 10000)
+    : DEFAULTS.rowCap;
 }
 
 // ----------------- settings tab -----------------
@@ -789,6 +902,26 @@ class SettingsTab extends PluginSettingTab {
           }),
       );
 
+    new Setting(this.containerEl)
+      .setName("Test DuckDB connection")
+      .setDesc("Runs a tiny local query using the current DuckDB setting.")
+      .addButton((b) =>
+        b.setButtonText("Test").onClick(async () => {
+          b.setDisabled(true);
+          b.setButtonText("Testing...");
+          try {
+            const result = await this.plugin.runQuery("SELECT 42 AS ok", "local");
+            new Notice(`DuckDB ok (${result.rows.length} row)`);
+          } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            new Notice(`DuckDB error: ${msg}`);
+          } finally {
+            b.setDisabled(false);
+            b.setButtonText("Test");
+          }
+        }),
+      );
+
     renderSectionHeader(this.containerEl, MOTHERDUCK_ICON, "MotherDuck", {
       text: "Used by ```motherduck code blocks. ",
       linkText: "motherduck.com",
@@ -834,6 +967,26 @@ class SettingsTab extends PluginSettingTab {
             await this.plugin.resetRuntimes("cloud");
           });
       });
+
+    new Setting(this.containerEl)
+      .setName("Test MotherDuck connection")
+      .setDesc("Runs a tiny cloud query using the current token.")
+      .addButton((b) =>
+        b.setButtonText("Test").onClick(async () => {
+          b.setDisabled(true);
+          b.setButtonText("Testing...");
+          try {
+            const result = await this.plugin.runQuery("SELECT 42 AS ok", "cloud");
+            new Notice(`MotherDuck ok (${result.rows.length} row)`);
+          } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            new Notice(`MotherDuck error: ${msg}`);
+          } finally {
+            b.setDisabled(false);
+            b.setButtonText("Test");
+          }
+        }),
+      );
 
     this.containerEl.createEl("h3", { text: "Scheduled refresh" });
 
@@ -960,7 +1113,7 @@ class SettingsTab extends PluginSettingTab {
           .onChange(async (v) => {
             const n = parseInt(v, 10);
             if (!Number.isNaN(n) && n > 0) {
-              this.plugin.settings.rowCap = n;
+              this.plugin.settings.rowCap = Math.min(Math.floor(n), 10000);
               await this.plugin.saveSettings();
             }
           }),

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "main.js",
   "scripts": {
     "dev": "node esbuild.config.mjs",
-    "build": "node esbuild.config.mjs production"
+    "build": "node esbuild.config.mjs production",
+    "test": "node scripts/run-tests.mjs"
   },
   "keywords": [
     "obsidian",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1,0 +1,54 @@
+import esbuild from "esbuild";
+import { spawnSync } from "node:child_process";
+import { mkdir, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const root = process.cwd();
+const testDir = path.join(root, "test");
+const outDir = path.join(tmpdir(), `obsidian-duckdb-motherduck-tests-${process.pid}`);
+
+async function findTests(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await findTests(fullPath));
+    } else if (entry.name.endsWith(".test.ts")) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+const testFiles = await findTests(testDir);
+if (testFiles.length === 0) {
+  console.error("No test files found.");
+  process.exit(1);
+}
+
+await rm(outDir, { recursive: true, force: true });
+await mkdir(outDir, { recursive: true });
+
+await esbuild.build({
+  entryPoints: testFiles,
+  outdir: outDir,
+  bundle: true,
+  platform: "node",
+  format: "esm",
+  target: "node20",
+  sourcemap: "inline",
+  external: ["node:*"],
+  logLevel: "silent",
+});
+
+const outFiles = testFiles.map((file) =>
+  path.join(outDir, path.basename(file).replace(/\.ts$/, ".js")),
+);
+const result = spawnSync(process.execPath, ["--test", ...outFiles], {
+  stdio: "inherit",
+});
+
+await rm(outDir, { recursive: true, force: true });
+process.exit(result.status ?? 1);

--- a/src/file-lock.ts
+++ b/src/file-lock.ts
@@ -1,0 +1,21 @@
+export class FileLock {
+  private locks = new Map<string, Promise<void>>();
+
+  async run<T>(path: string, task: () => Promise<T>): Promise<T> {
+    const previous = this.locks.get(path) ?? Promise.resolve();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const next = previous.catch(() => undefined).then(() => gate);
+    this.locks.set(path, next);
+    await previous.catch(() => undefined);
+
+    try {
+      return await task();
+    } finally {
+      release();
+      if (this.locks.get(path) === next) this.locks.delete(path);
+    }
+  }
+}

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -1,0 +1,69 @@
+import type { Connection } from "./types";
+
+export interface FencedBlock {
+  sql: string;
+  startLine: number;
+  endLine: number;
+  connection: Connection;
+}
+
+export function findBlocks(content: string): FencedBlock[] {
+  const lines = content.split("\n");
+  const blocks: FencedBlock[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const open = lines[i].match(/^ {0,3}(`{3,}|~{3,})\s*(motherduck|duckdb)(?:\s+.*)?$/);
+    if (!open) {
+      i++;
+      continue;
+    }
+
+    const fence = open[1];
+    const fenceChar = fence[0];
+    const closeRe = new RegExp(`^ {0,3}${escapeRegExp(fenceChar)}{${fence.length},}\\s*$`);
+    const connection: Connection = open[2] === "duckdb" ? "local" : "cloud";
+    const start = i;
+    i++;
+
+    const sqlLines: string[] = [];
+    while (i < lines.length && !closeRe.test(lines[i])) {
+      sqlLines.push(lines[i]);
+      i++;
+    }
+
+    if (i < lines.length) {
+      blocks.push({ sql: sqlLines.join("\n"), startLine: start, endLine: i, connection });
+      i++;
+    }
+  }
+
+  return blocks;
+}
+
+export function writeSentinelAfterBlock(
+  content: string,
+  block: FencedBlock,
+  renderedResult: string,
+): string {
+  const lines = content.split("\n");
+  const afterBlock = block.endLine + 1;
+  let cutEnd = afterBlock;
+  let j = afterBlock;
+
+  while (j < lines.length && lines[j].trim() === "") j++;
+
+  if (j < lines.length && /<!-- md:cache hash=/.test(lines[j])) {
+    let k = j;
+    while (k < lines.length && !/<!-- md:cache-end -->/.test(lines[k])) k++;
+    if (k < lines.length) cutEnd = k + 1;
+  }
+
+  const before = lines.slice(0, afterBlock).join("\n");
+  const rest = lines.slice(cutEnd).join("\n");
+  return before + "\n\n" + renderedResult + (rest ? "\n\n" + rest : "\n");
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/src/path.ts
+++ b/src/path.ts
@@ -1,0 +1,6 @@
+export function shortPathLabel(rawPath: string): string {
+  const v = (rawPath || "").trim();
+  if (!v || v === ":memory:") return ":memory:";
+  const m = v.match(/[^/\\]+$/);
+  return m ? m[0] : v;
+}

--- a/src/query-block.ts
+++ b/src/query-block.ts
@@ -1,0 +1,157 @@
+import { App, MarkdownPostProcessorContext, Notice, TFile, setIcon } from "obsidian";
+import { DUCKDB_ICON, MOTHERDUCK_ICON } from "./icons";
+import { shortPathLabel } from "./path";
+import { renderDomTable } from "./table";
+import type { Connection, QueryRunResult, Settings } from "./types";
+
+export interface QueryBlockHost {
+  app: App;
+  settings: Settings;
+  runQuery(sql: string, connection: Connection): Promise<QueryRunResult>;
+  freezeRenderedBlock(
+    ctx: MarkdownPostProcessorContext,
+    el: HTMLElement,
+    sql: string,
+    connection: Connection,
+  ): Promise<void>;
+}
+
+export function renderQueryBlock(
+  host: QueryBlockHost,
+  connection: Connection,
+  src: string,
+  el: HTMLElement,
+  ctx: MarkdownPostProcessorContext,
+) {
+  const sql = src.trim();
+  if (!sql) {
+    el.createEl("em", { text: connection === "cloud" ? "empty motherduck block" : "empty duckdb block" });
+    return;
+  }
+
+  const wrap = el.createDiv({ cls: "motherduck-block" });
+  const badge = wrap.createDiv({ cls: "motherduck-block__badge" });
+  const iconWrap = badge.createDiv({ cls: "motherduck-block__engine-icon" });
+  iconWrap.innerHTML = connection === "cloud" ? MOTHERDUCK_ICON : DUCKDB_ICON;
+
+  if (connection === "cloud") {
+    badge.createEl("span", { text: "MotherDuck" });
+  } else {
+    badge.createEl("span", { text: "DuckDB " });
+    badge.createEl("code", { text: shortPathLabel(host.settings.dbPath) });
+  }
+
+  attachRefreshDropdown(host, badge, ctx);
+
+  const pre = wrap.createEl("pre", { cls: "motherduck-block__sql" });
+  pre.createEl("code", { text: sql });
+
+  const btnRow = wrap.createDiv({ cls: "motherduck-block__controls" });
+
+  const runBtn = btnRow.createEl("button", { cls: "motherduck-block__button" });
+  setIcon(runBtn, "play");
+  runBtn.appendText("Run");
+  runBtn.title = "Run query";
+  runBtn.setAttr("aria-label", "Run query");
+
+  const freezeBtn = btnRow.createEl("button", { cls: "motherduck-block__button" });
+  setIcon(freezeBtn, "pin");
+  freezeBtn.appendText("Freeze");
+  freezeBtn.title = "Run and freeze result below this block";
+  freezeBtn.setAttr("aria-label", "Run and freeze result below this block");
+
+  const status = btnRow.createEl("span", { cls: "motherduck-block__status" });
+  const resultEl = wrap.createDiv({ cls: "motherduck-block__result" });
+
+  runBtn.addEventListener("click", async () => {
+    resultEl.empty();
+    status.setText("running…");
+    setButtonsDisabled(true);
+    const t0 = performance.now();
+    try {
+      const { rows, columns } = await host.runQuery(sql, connection);
+      const dt = Math.round(performance.now() - t0);
+      status.setText(`${rows.length} row(s) · ${dt} ms`);
+      renderDomTable(resultEl, rows, columns, host.settings.rowCap);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      status.setText("error");
+      resultEl.createEl("pre", { cls: "motherduck-block__error", text: msg });
+    } finally {
+      setButtonsDisabled(false);
+    }
+  });
+
+  freezeBtn.addEventListener("click", async () => {
+    status.setText("freezing…");
+    setButtonsDisabled(true);
+    try {
+      await host.freezeRenderedBlock(ctx, el, sql, connection);
+      status.setText("frozen ✓");
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      status.setText(`error: ${msg}`);
+      console.error("[motherduck] freeze failed", e);
+    } finally {
+      setButtonsDisabled(false);
+    }
+  });
+
+  function setButtonsDisabled(disabled: boolean) {
+    if (disabled) {
+      runBtn.setAttr("disabled", "true");
+      freezeBtn.setAttr("disabled", "true");
+    } else {
+      runBtn.removeAttribute("disabled");
+      freezeBtn.removeAttribute("disabled");
+    }
+  }
+}
+
+function attachRefreshDropdown(
+  host: QueryBlockHost,
+  parent: HTMLElement,
+  ctx: MarkdownPostProcessorContext,
+) {
+  const file = host.app.vault.getAbstractFileByPath(ctx.sourcePath);
+  if (!(file instanceof TFile)) return;
+
+  const group = parent.createDiv({ cls: "motherduck-refresh-control" });
+  const iconHost = group.createDiv({ cls: "motherduck-refresh-control__icon" });
+  setIcon(iconHost, "refresh-cw");
+
+  const select = group.createEl("select", { cls: "motherduck-refresh-control__select" }) as HTMLSelectElement;
+  select.title = "Auto-refresh this note (writes to its frontmatter)";
+  select.setAttr("aria-label", "Auto-refresh this note");
+
+  const opts: Array<{ value: "" | "daily" | "weekly"; label: string }> = [
+    { value: "", label: "Refresh: none" },
+    { value: "daily", label: "Refresh: daily" },
+    { value: "weekly", label: "Refresh: weekly" },
+  ];
+  for (const opt of opts) {
+    const o = select.createEl("option");
+    o.value = opt.value;
+    o.text = opt.label;
+  }
+
+  const fm = host.app.metadataCache.getFileCache(file)?.frontmatter;
+  const current = fm?.["duckdb-motherduck-refresh"];
+  select.value = current === "daily" || current === "weekly" ? current : "";
+
+  select.addEventListener("change", async () => {
+    const v = select.value as "" | "daily" | "weekly";
+    try {
+      await host.app.fileManager.processFrontMatter(file, (fmEdit) => {
+        if (v === "") {
+          delete fmEdit["duckdb-motherduck-refresh"];
+        } else {
+          fmEdit["duckdb-motherduck-refresh"] = v;
+        }
+      });
+    } catch (e) {
+      console.error("[motherduck] failed to update refresh cadence frontmatter", e);
+      new Notice("failed to update refresh cadence");
+    }
+  });
+}

--- a/src/runtime/duckdb.ts
+++ b/src/runtime/duckdb.ts
@@ -7,7 +7,7 @@ import {
 } from "@duckdb/duckdb-wasm";
 import workerEh from "@duckdb/duckdb-wasm/dist/duckdb-browser-eh.worker.js";
 import workerMvp from "@duckdb/duckdb-wasm/dist/duckdb-browser-mvp.worker.js";
-import { Row, QueryResult, Runtime } from "./index";
+import { Row, QueryResult, Runtime, normalizeValue } from "./index";
 
 // Electron's renderer exposes Node's `require`. Used to read real disk files
 // for read-only queries via DuckDB-Wasm's registerFileBuffer. Not available
@@ -144,7 +144,7 @@ export class DuckDBWasmRuntime implements Runtime {
     const columns = table.schema.fields.map((f) => f.name);
     const rows: Row[] = table.toArray().map((r: Record<string, unknown>) => {
       const obj: Row = {};
-      for (const c of columns) obj[c] = normalize(r[c]);
+      for (const c of columns) obj[c] = normalizeValue(r[c]);
       return obj;
     });
     return { rows, columns };
@@ -161,14 +161,4 @@ export class DuckDBWasmRuntime implements Runtime {
       this.workerUrl = null;
     }
   }
-}
-
-// Arrow types don't JSON-serialize cleanly. Coerce BigInt, Date, and TypedArrays
-// to plain values so renderers and the sentinel hash stay stable.
-function normalize(v: unknown): unknown {
-  if (v === null || v === undefined) return v;
-  if (typeof v === "bigint") return v.toString();
-  if (v instanceof Date) return v.toISOString();
-  if (v instanceof Uint8Array) return `<${v.length} bytes>`;
-  return v;
 }

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -11,3 +11,30 @@ export interface Runtime {
   close(): Promise<void>;
   label(): string;
 }
+
+// DuckDB and MotherDuck both return values that can be awkward to render or
+// serialize directly: bigint, Arrow vectors, and custom MotherDuck value
+// objects. Normalize at the runtime boundary so the UI and frozen markdown only
+// deal with plain display values.
+export function normalizeValue(v: unknown): unknown {
+  if (v === null || v === undefined) return v;
+  if (typeof v === "bigint") return v.toString();
+  if (v instanceof Date) return v.toISOString();
+  if (v instanceof Uint8Array) return `<${v.length} bytes>`;
+  if (Array.isArray(v)) return v.map((item) => normalizeValue(item));
+  if (typeof v === "object") {
+    const maybeStringifiable = v as { toString?: () => string };
+    if (
+      typeof maybeStringifiable.toString === "function" &&
+      maybeStringifiable.toString !== Object.prototype.toString
+    ) {
+      return maybeStringifiable.toString();
+    }
+    const out: Row = {};
+    for (const [key, value] of Object.entries(v as Record<string, unknown>)) {
+      out[key] = normalizeValue(value);
+    }
+    return out;
+  }
+  return v;
+}

--- a/src/runtime/manager.ts
+++ b/src/runtime/manager.ts
@@ -1,0 +1,117 @@
+import { DuckDBWasmRuntime } from "./duckdb";
+import { MotherDuckRuntime } from "./motherduck";
+import type { Row, Runtime } from ".";
+import type { Connection, QueryRunResult, Settings } from "../types";
+
+export class RuntimeManager {
+  private localRuntime: Runtime | null = null;
+  private cloudRuntime: Runtime | null = null;
+  private localRuntimePromise: Promise<Runtime> | null = null;
+  private cloudRuntimePromise: Promise<Runtime> | null = null;
+  private generation: Record<Connection, number> = {
+    local: 0,
+    cloud: 0,
+  };
+  private queryQueues: Record<Connection, Promise<unknown>> = {
+    local: Promise.resolve(),
+    cloud: Promise.resolve(),
+  };
+
+  constructor(private getSettings: () => Settings) {}
+
+  async reset(only?: Connection) {
+    if (!only || only === "local") {
+      this.generation.local++;
+      this.localRuntimePromise = null;
+      this.queryQueues.local = Promise.resolve();
+      try {
+        await this.localRuntime?.close();
+      } catch (e) {
+        console.error("[motherduck] close local failed", e);
+      }
+      this.localRuntime = null;
+    }
+
+    if (!only || only === "cloud") {
+      this.generation.cloud++;
+      this.cloudRuntimePromise = null;
+      this.queryQueues.cloud = Promise.resolve();
+      try {
+        await this.cloudRuntime?.close();
+      } catch (e) {
+        console.error("[motherduck] close cloud failed", e);
+      }
+      this.cloudRuntime = null;
+    }
+  }
+
+  async runQuery(sql: string, connection: Connection): Promise<QueryRunResult> {
+    return this.enqueueQuery(connection, async () => {
+      const rt = await this.getRuntime(connection);
+      return rt.runQuery(sql);
+    });
+  }
+
+  private async getRuntime(connection: Connection): Promise<Runtime> {
+    const settings = this.getSettings();
+
+    if (connection === "cloud") {
+      if (!settings.mdToken) {
+        throw new Error("MotherDuck token not set. Configure it in plugin settings.");
+      }
+      if (this.cloudRuntime) return this.cloudRuntime;
+      if (!this.cloudRuntimePromise) {
+        const rt = new MotherDuckRuntime(settings.mdToken);
+        const generation = this.generation.cloud;
+        this.cloudRuntimePromise = this.initRuntime(rt, "cloud", generation);
+      }
+      return this.cloudRuntimePromise;
+    }
+
+    if (this.localRuntime) return this.localRuntime;
+    if (!this.localRuntimePromise) {
+      const rt = new DuckDBWasmRuntime(settings.dbPath);
+      const generation = this.generation.local;
+      this.localRuntimePromise = this.initRuntime(rt, "local", generation);
+    }
+    return this.localRuntimePromise;
+  }
+
+  private initRuntime(rt: Runtime, connection: Connection, generation: number): Promise<Runtime> {
+    return rt
+      .init()
+      .then(() => {
+        if (this.generation[connection] !== generation) {
+          void rt.close();
+          throw new Error(`${connectionLabel(connection)} connection reset while initializing. Retry the query.`);
+        }
+        if (connection === "cloud") this.cloudRuntime = rt;
+        else this.localRuntime = rt;
+        return rt;
+      })
+      .catch(async (e) => {
+        await rt.close().catch((closeError) => {
+          console.error(`[motherduck] close failed after ${connection} init error`, closeError);
+        });
+        throw e;
+      })
+      .finally(() => {
+        if (connection === "cloud") this.cloudRuntimePromise = null;
+        else this.localRuntimePromise = null;
+      });
+  }
+
+  private enqueueQuery<T extends QueryRunResult | { rows: Row[]; columns: string[] }>(
+    connection: Connection,
+    op: () => Promise<T>,
+  ): Promise<T> {
+    const previous = this.queryQueues[connection].catch(() => undefined);
+    const next = previous.then(op);
+    this.queryQueues[connection] = next.catch(() => undefined);
+    return next;
+  }
+}
+
+function connectionLabel(connection: Connection): string {
+  return connection === "cloud" ? "MotherDuck" : "DuckDB";
+}

--- a/src/runtime/motherduck.ts
+++ b/src/runtime/motherduck.ts
@@ -1,5 +1,5 @@
 import { MDConnection } from "@motherduck/wasm-client";
-import { Row, QueryResult, Runtime } from "./index";
+import { Row, QueryResult, Runtime, normalizeValue } from "./index";
 
 export class MotherDuckRuntime implements Runtime {
   private connection: MDConnection | null = null;
@@ -27,8 +27,12 @@ export class MotherDuckRuntime implements Runtime {
       const err = (result as { err?: { message?: string } }).err;
       throw new Error(err?.message ?? JSON.stringify(err));
     }
-    const rows = result.result.data.toRows() as Row[];
-    const columns = rows.length > 0 ? Object.keys(rows[0]) : [];
+    const columns = [...result.result.data.deduplicatedColumnNames()];
+    const rows = result.result.data.toRows().map((row) => {
+      const out: Row = {};
+      for (const column of columns) out[column] = normalizeValue(row[column]);
+      return out;
+    });
     return { rows, columns };
   }
 

--- a/src/schedule.ts
+++ b/src/schedule.ts
@@ -1,0 +1,16 @@
+import { CADENCE_MS, type Cadence } from "./types";
+
+export function isOverdue(cadence: Cadence, lastRefresh: string | null, now = Date.now()): boolean {
+  if (!lastRefresh) return true;
+  const last = Date.parse(lastRefresh);
+  if (Number.isNaN(last)) return true;
+  return now - last >= CADENCE_MS[cadence];
+}
+
+export function formatLogTimestamp(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -1,0 +1,319 @@
+import { App, Notice, PluginSettingTab, Setting, TFile, type Plugin } from "obsidian";
+import { DUCKDB_ICON, MOTHERDUCK_ICON } from "./icons";
+import { formatLogTimestamp } from "./schedule";
+import type { Connection, QueryRunResult, Settings, SweepResult } from "./types";
+
+export interface SettingsTabHost {
+  app: App;
+  settings: Settings;
+  saveSettings(): Promise<void>;
+  resetRuntimes(only?: Connection): Promise<void>;
+  runQuery(sql: string, connection: Connection): Promise<QueryRunResult>;
+  startScheduler(): void;
+  stopScheduler(): void;
+  runManualSweep(): Promise<SweepResult>;
+}
+
+export class SettingsTab extends PluginSettingTab {
+  constructor(app: App, private plugin: SettingsTabHost & Plugin) {
+    super(app, plugin);
+  }
+
+  display(): void {
+    this.containerEl.empty();
+
+    const intro = this.containerEl.createEl("p", { cls: "setting-item-description" });
+    intro.setText(
+      "Run SQL in your notes against a local DuckDB file or your MotherDuck workspace. " +
+        "Results render live, and can be frozen as inline markdown tables, either per-block via the Freeze button or in bulk via the 'Refresh all queries' command.",
+    );
+
+    renderSectionHeader(this.containerEl, DUCKDB_ICON, "DuckDB", {
+      text: "Used by ```duckdb code blocks. ",
+      linkText: "duckdb.org",
+      href: "https://duckdb.org",
+    });
+
+    new Setting(this.containerEl)
+      .setName("Path to local DuckDB file")
+      .setDesc(
+        createFragment((frag) => {
+          frag.appendText("Default ");
+          frag.createEl("code", { text: ":memory:" });
+          frag.appendText(
+            " is an ephemeral in-memory database. Or paste an absolute path to query an existing on-disk file (read-only, writes don't persist back). Examples: ",
+          );
+          frag.createEl("code", { text: "/Users/you/data.duckdb" });
+          frag.appendText(", ");
+          frag.createEl("code", { text: "/home/you/data.duckdb" });
+          frag.appendText(", ");
+          frag.createEl("code", { text: "C:\\Users\\you\\data.duckdb" });
+          frag.appendText(".");
+        }),
+      )
+      .addText((t) =>
+        t
+          .setPlaceholder(":memory:")
+          .setValue(this.plugin.settings.dbPath)
+          .onChange(async (v) => {
+            this.plugin.settings.dbPath = v.trim() || ":memory:";
+            await this.plugin.saveSettings();
+            await this.plugin.resetRuntimes("local");
+          }),
+      );
+
+    new Setting(this.containerEl)
+      .setName("Test DuckDB connection")
+      .setDesc("Runs a tiny local query using the current DuckDB setting.")
+      .addButton((b) =>
+        b.setButtonText("Test").onClick(async () => {
+          b.setDisabled(true);
+          b.setButtonText("Testing...");
+          try {
+            const result = await this.plugin.runQuery("SELECT 42 AS ok", "local");
+            new Notice(`DuckDB ok (${result.rows.length} row)`);
+          } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            new Notice(`DuckDB error: ${msg}`);
+          } finally {
+            b.setDisabled(false);
+            b.setButtonText("Test");
+          }
+        }),
+      );
+
+    renderSectionHeader(this.containerEl, MOTHERDUCK_ICON, "MotherDuck", {
+      text: "Used by ```motherduck code blocks. ",
+      linkText: "motherduck.com",
+      href: "https://motherduck.com",
+    });
+
+    new Setting(this.containerEl)
+      .setName("MotherDuck token")
+      .setDesc(
+        createFragment((frag) => {
+          frag.appendText(
+            "Paste a MotherDuck access token to query the cloud instead of local DuckDB. Stored unencrypted in ",
+          );
+          frag.createEl("code", { text: "data.json" });
+          frag.appendText(" inside this vault's plugin folder; if you sync this vault publicly, unset the token first.");
+          frag.createEl("br");
+          frag.createEl("br");
+          frag.appendText("Get a token: prefer a ");
+          const sa = frag.createEl("a", {
+            href: "https://motherduck.com/docs/key-tasks/service-accounts-guide/create-and-configure-service-accounts/",
+            text: "service account token",
+          });
+          sa.setAttr("target", "_blank");
+          sa.setAttr("rel", "noopener noreferrer");
+          frag.appendText(" (scoped permissions, individually revocable) or use a ");
+          const pat = frag.createEl("a", {
+            href: "https://motherduck.com/docs/key-tasks/authenticating-and-connecting-to-motherduck/authenticating-to-motherduck/#authentication-using-an-access-token",
+            text: "personal access token",
+          });
+          pat.setAttr("target", "_blank");
+          pat.setAttr("rel", "noopener noreferrer");
+          frag.appendText(".");
+        }),
+      )
+      .addText((t) => {
+        t.inputEl.type = "password";
+        t.inputEl.autocomplete = "off";
+        t.setPlaceholder("eyJ... (leave empty for local DuckDB)")
+          .setValue(this.plugin.settings.mdToken)
+          .onChange(async (v) => {
+            this.plugin.settings.mdToken = v.trim();
+            await this.plugin.saveSettings();
+            await this.plugin.resetRuntimes("cloud");
+          });
+      });
+
+    new Setting(this.containerEl)
+      .setName("Test MotherDuck connection")
+      .setDesc("Runs a tiny cloud query using the current token.")
+      .addButton((b) =>
+        b.setButtonText("Test").onClick(async () => {
+          b.setDisabled(true);
+          b.setButtonText("Testing...");
+          try {
+            const result = await this.plugin.runQuery("SELECT 42 AS ok", "cloud");
+            new Notice(`MotherDuck ok (${result.rows.length} row)`);
+          } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            new Notice(`MotherDuck error: ${msg}`);
+          } finally {
+            b.setDisabled(false);
+            b.setButtonText("Test");
+          }
+        }),
+      );
+
+    this.containerEl.createEl("h3", { text: "Scheduled refresh" });
+
+    const scheduleDesc = this.containerEl.createEl("p", { cls: "setting-item-description" });
+    scheduleDesc.appendText("Pick a cadence in the ");
+    scheduleDesc.createEl("code", { text: "Refresh" });
+    scheduleDesc.appendText(" dropdown above any SQL block to opt that note in. The plugin writes ");
+    scheduleDesc.createEl("code", { text: "duckdb-motherduck-refresh" });
+    scheduleDesc.appendText(
+      " to the note's frontmatter, sweeps once an hour while Obsidian is running, and refreshes overdue notes. The active editor is skipped to avoid stomping in-progress edits.",
+    );
+
+    new Setting(this.containerEl)
+      .setName("Auto-refresh scheduled notes")
+      .setDesc("When on, opted-in notes refresh automatically based on their cadence.")
+      .addToggle((t) =>
+        t.setValue(this.plugin.settings.scheduleEnabled).onChange(async (v) => {
+          this.plugin.settings.scheduleEnabled = v;
+          await this.plugin.saveSettings();
+          if (v) this.plugin.startScheduler();
+          else this.plugin.stopScheduler();
+        }),
+      );
+
+    new Setting(this.containerEl)
+      .setName("Refresh all notes with queries now")
+      .setDesc("Sweeps every note in the vault that has a SQL block, ignoring cadence and frontmatter opt-in. Available even when auto-refresh is off.")
+      .addButton((b) =>
+        b.setButtonText("Refresh now").onClick(async () => {
+          b.setDisabled(true);
+          b.setButtonText("Refreshing...");
+          try {
+            const r = await this.plugin.runManualSweep();
+            new Notice(
+              `Refreshed ${r.refreshed} note(s), ${r.errored} error(s), ${r.checked} scanned`,
+            );
+          } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            new Notice(`error: ${msg}`);
+          } finally {
+            b.setDisabled(false);
+            b.setButtonText("Refresh now");
+            this.display();
+          }
+        }),
+      );
+
+    this.renderActivityLog();
+
+    this.containerEl.createEl("h3", { text: "General" });
+
+    new Setting(this.containerEl)
+      .setName("Row cap")
+      .setDesc("Max rows rendered inline / frozen. Truncation notice appended if exceeded.")
+      .addText((t) =>
+        t
+          .setPlaceholder("100")
+          .setValue(String(this.plugin.settings.rowCap))
+          .onChange(async (v) => {
+            const n = parseInt(v, 10);
+            if (!Number.isNaN(n) && n > 0) {
+              this.plugin.settings.rowCap = Math.min(Math.floor(n), 10000);
+              await this.plugin.saveSettings();
+            }
+          }),
+      );
+  }
+
+  private renderActivityLog() {
+    const logTitle = this.containerEl.createEl("h4", { text: "Activity log" });
+    logTitle.style.marginTop = "16px";
+    logTitle.style.marginBottom = "4px";
+
+    if (this.plugin.settings.refreshLog.length === 0) {
+      this.containerEl.createEl("p", {
+        cls: "setting-item-description",
+        text: "No refreshes recorded yet.",
+      });
+      return;
+    }
+
+    const logEl = this.containerEl.createDiv();
+    logEl.style.maxHeight = "300px";
+    logEl.style.overflowY = "auto";
+    logEl.style.border = "1px solid var(--background-modifier-border)";
+    logEl.style.borderRadius = "6px";
+    logEl.style.padding = "8px";
+    logEl.style.fontSize = "0.85em";
+    logEl.style.fontFamily = "var(--font-monospace)";
+    logEl.style.lineHeight = "1.5";
+
+    for (const entry of this.plugin.settings.refreshLog.slice(0, 30)) {
+      const row = logEl.createDiv();
+      const ts = row.createEl("span", { text: formatLogTimestamp(entry.ts) });
+      ts.style.opacity = "0.7";
+      row.appendText("  ");
+      const trigger = row.createEl("span", { text: entry.trigger });
+      trigger.style.opacity = "0.7";
+      row.appendText("  ");
+
+      const linkEl = row.createEl("a", { text: entry.path });
+      linkEl.style.cursor = "pointer";
+      linkEl.addEventListener("click", (e) => {
+        e.preventDefault();
+        const f = this.plugin.app.vault.getAbstractFileByPath(entry.path);
+        if (f instanceof TFile) {
+          this.plugin.app.workspace.getLeaf().openFile(f);
+        }
+      });
+
+      if (entry.blocks === 0 && entry.errored === 0 && entry.errorMessage) {
+        row.appendText("  ");
+        const err = row.createEl("span", { text: `error: ${entry.errorMessage}` });
+        err.style.color = "var(--text-error)";
+      } else {
+        row.appendText(`  ${entry.blocks} refreshed`);
+        if (entry.errored > 0) {
+          const err = row.createEl("span", {
+            text: entry.errorMessage
+              ? `, ${entry.errored} errored: ${entry.errorMessage}`
+              : `, ${entry.errored} errored`,
+          });
+          err.style.color = "var(--text-error)";
+        }
+      }
+    }
+
+    new Setting(this.containerEl).addButton((b) =>
+      b.setButtonText("Clear log").onClick(async () => {
+        this.plugin.settings.refreshLog = [];
+        await this.plugin.saveSettings();
+        this.display();
+      }),
+    );
+  }
+}
+
+function renderSectionHeader(
+  parent: HTMLElement,
+  svgMarkup: string,
+  title: string,
+  tagline?: { text: string; linkText: string; href: string },
+) {
+  const row = parent.createDiv();
+  row.style.display = "flex";
+  row.style.alignItems = "center";
+  row.style.gap = "10px";
+  row.style.marginTop = "24px";
+  row.style.marginBottom = tagline ? "4px" : "8px";
+  row.style.paddingBottom = "6px";
+  row.style.borderBottom = "1px solid var(--background-modifier-border)";
+
+  const iconWrap = row.createDiv();
+  iconWrap.style.display = "flex";
+  iconWrap.style.alignItems = "center";
+  iconWrap.innerHTML = svgMarkup;
+
+  const h = row.createEl("h3", { text: title });
+  h.style.margin = "0";
+
+  if (tagline) {
+    const desc = parent.createEl("p", { cls: "setting-item-description" });
+    desc.style.marginTop = "0";
+    desc.style.marginBottom = "8px";
+    desc.appendText(tagline.text);
+    const a = desc.createEl("a", { href: tagline.href, text: tagline.linkText });
+    a.setAttr("target", "_blank");
+    a.setAttr("rel", "noopener noreferrer");
+  }
+}

--- a/src/table.ts
+++ b/src/table.ts
@@ -1,0 +1,95 @@
+import type { Row } from "./runtime";
+import type { Connection } from "./types";
+import { DEFAULTS } from "./types";
+
+export function simpleHash(s: string): string {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = ((h << 5) - h + s.charCodeAt(i)) | 0;
+  return (h >>> 0).toString(16).padStart(8, "0");
+}
+
+export function escapeCell(v: unknown): string {
+  if (v === null || v === undefined) return "";
+  const s = typeof v === "object" ? JSON.stringify(v) : String(v);
+  return s.replace(/\\/g, "\\\\").replace(/\|/g, "\\|").replace(/\n/g, " ").replace(/\r/g, "");
+}
+
+export function renderMarkdownTable(
+  rows: Row[],
+  columns: string[],
+  sql: string,
+  connection: Connection,
+  rowCap: number,
+): string {
+  const hash = simpleHash(`${connection}\n${sql.trim()}`);
+  const ts = new Date().toISOString();
+  const totalRows = rows.length;
+  const cap = normalizedRowCap(rowCap);
+  const shown = rows.slice(0, cap);
+
+  const open = `<!-- md:cache hash=${hash} conn=${connection} ts=${ts} rows=${totalRows} -->`;
+  const close = "<!-- md:cache-end -->";
+
+  if (columns.length === 0) {
+    return `${open}\n\n_(0 rows)_\n\n${close}`;
+  }
+
+  const header = "| " + columns.map(escapeCell).join(" | ") + " |";
+  const sep = "| " + columns.map(() => "---").join(" | ") + " |";
+  const body = shown.map((r) => "| " + columns.map((c) => escapeCell(r[c])).join(" | ") + " |");
+  const emptyNotice = totalRows === 0 ? "\n\n> 0 rows" : "";
+  const truncated =
+    totalRows > cap ? `\n\n> … ${totalRows - cap} more rows hidden (cap ${cap})` : "";
+
+  return `${open}\n\n${header}\n${sep}\n${body.join("\n")}${emptyNotice}${truncated}\n\n${close}`;
+}
+
+export function renderDomTable(
+  parent: HTMLElement & { createEl: (tag: string, options?: Record<string, unknown>) => HTMLElement },
+  rows: Row[],
+  columns: string[],
+  rowCap: number,
+) {
+  if (columns.length === 0) {
+    parent.createEl("em", { text: "(0 rows)" });
+    return;
+  }
+
+  const cap = normalizedRowCap(rowCap);
+  const shown = rows.slice(0, cap);
+  const table = parent.createEl("table", { cls: "motherduck-result-table" });
+  const thead = table.createEl("thead").createEl("tr");
+
+  for (const c of columns) {
+    thead.createEl("th", { text: c });
+  }
+
+  const tbody = table.createEl("tbody");
+  for (const row of shown) {
+    const tr = tbody.createEl("tr");
+    for (const c of columns) {
+      const td = tr.createEl("td");
+      const v = row[c];
+      td.setText(v === null || v === undefined ? "" : typeof v === "object" ? JSON.stringify(v) : String(v));
+    }
+  }
+
+  if (rows.length === 0) {
+    const empty = parent.createEl("div", { cls: "motherduck-muted", text: "0 rows" });
+    empty.style.marginTop = "4px";
+  }
+
+  if (rows.length > cap) {
+    const more = parent.createEl("div", {
+      cls: "motherduck-muted",
+      text: `… ${rows.length - cap} more rows hidden (cap ${cap})`,
+    });
+    more.style.marginTop = "4px";
+  }
+}
+
+export function normalizedRowCap(rowCap: number): number {
+  return Number.isFinite(rowCap) && rowCap > 0
+    ? Math.min(Math.floor(rowCap), 10000)
+    : DEFAULTS.rowCap;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,49 @@
+import type { Row } from "./runtime";
+
+export type Connection = "local" | "cloud";
+export type Cadence = "daily" | "weekly";
+
+export const CADENCE_MS: Record<Cadence, number> = {
+  daily: 24 * 60 * 60 * 1000,
+  weekly: 7 * 24 * 60 * 60 * 1000,
+};
+
+export const SWEEP_INTERVAL_MS = 60 * 60 * 1000;
+export const STARTUP_DELAY_MS = 5 * 1000;
+export const LOG_CAP = 100;
+
+export interface RefreshLogEntry {
+  ts: string;
+  path: string;
+  trigger: "schedule" | "manual";
+  blocks: number;
+  errored: number;
+  errorMessage?: string;
+}
+
+export interface Settings {
+  mdToken: string;
+  dbPath: string;
+  rowCap: number;
+  scheduleEnabled: boolean;
+  refreshLog: RefreshLogEntry[];
+}
+
+export interface QueryRunResult {
+  rows: Row[];
+  columns: string[];
+}
+
+export interface SweepResult {
+  refreshed: number;
+  errored: number;
+  checked: number;
+}
+
+export const DEFAULTS: Settings = {
+  mdToken: "",
+  dbPath: ":memory:",
+  rowCap: 100,
+  scheduleEnabled: false,
+  refreshLog: [],
+};

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,113 @@
+.motherduck-block {
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 6px;
+  padding: 10px;
+  margin: 8px 0;
+  background: var(--background-primary);
+}
+
+.motherduck-block__badge {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  margin-bottom: 6px;
+  color: var(--text-muted);
+  font-size: var(--font-ui-smaller);
+}
+
+.motherduck-block__engine-icon,
+.motherduck-refresh-control__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+}
+
+.motherduck-block__engine-icon svg {
+  width: 14px;
+  height: 14px;
+}
+
+.motherduck-refresh-control {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: auto;
+}
+
+.motherduck-refresh-control__icon svg {
+  width: 12px;
+  height: 12px;
+}
+
+.motherduck-refresh-control__select {
+  max-width: 150px;
+  font-size: var(--font-ui-smaller);
+}
+
+.motherduck-block__sql {
+  margin: 0 0 8px;
+  overflow-x: auto;
+  font-size: var(--font-ui-smaller);
+}
+
+.motherduck-block__controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.motherduck-block__button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: var(--input-height);
+}
+
+.motherduck-block__button svg {
+  width: 16px;
+  height: 16px;
+}
+
+.motherduck-block__status,
+.motherduck-muted {
+  color: var(--text-muted);
+  font-size: var(--font-ui-smaller);
+}
+
+.motherduck-block__result {
+  margin-top: 8px;
+  overflow-x: auto;
+}
+
+.motherduck-block__error {
+  color: var(--text-error);
+  white-space: pre-wrap;
+}
+
+.motherduck-result-table {
+  border-collapse: collapse;
+  font-size: var(--font-ui-smaller);
+}
+
+.motherduck-result-table th,
+.motherduck-result-table td {
+  border-bottom: 1px solid var(--background-modifier-border);
+  padding: 4px 8px;
+  text-align: left;
+  vertical-align: top;
+}
+
+@media (max-width: 520px) {
+  .motherduck-block__badge {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .motherduck-refresh-control {
+    width: 100%;
+    margin-left: 0;
+  }
+}

--- a/test/file-lock.test.ts
+++ b/test/file-lock.test.ts
@@ -1,0 +1,58 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { FileLock } from "../src/file-lock";
+
+test("FileLock serializes work for the same file", async () => {
+  const lock = new FileLock();
+  const events: string[] = [];
+  let releaseFirst!: () => void;
+
+  const first = lock.run("note.md", async () => {
+    events.push("first:start");
+    await new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    events.push("first:end");
+    return 1;
+  });
+
+  const second = lock.run("note.md", async () => {
+    events.push("second:start");
+    return 2;
+  });
+
+  await flushMicrotasks();
+  assert.deepEqual(events, ["first:start"]);
+
+  releaseFirst();
+  assert.deepEqual(await Promise.all([first, second]), [1, 2]);
+  assert.deepEqual(events, ["first:start", "first:end", "second:start"]);
+});
+
+test("FileLock allows different files to run concurrently", async () => {
+  const lock = new FileLock();
+  const events: string[] = [];
+  let releaseFirst!: () => void;
+
+  const first = lock.run("a.md", async () => {
+    events.push("a:start");
+    await new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    events.push("a:end");
+  });
+
+  const second = lock.run("b.md", async () => {
+    events.push("b:start");
+  });
+
+  await second;
+  assert.deepEqual(events, ["a:start", "b:start"]);
+  releaseFirst();
+  await first;
+});
+
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+}

--- a/test/markdown.test.ts
+++ b/test/markdown.test.ts
@@ -1,0 +1,89 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { findBlocks, writeSentinelAfterBlock } from "../src/markdown";
+
+test("findBlocks parses duckdb and motherduck fences with info text", () => {
+  const blocks = findBlocks(
+    [
+      "# Dashboard",
+      "```duckdb title=\"local\"",
+      "select 1 as x",
+      "```",
+      "text",
+      "~~~~motherduck",
+      "select 2 as y",
+      "~~~~",
+    ].join("\n"),
+  );
+
+  assert.deepEqual(blocks, [
+    { connection: "local", sql: "select 1 as x", startLine: 1, endLine: 3 },
+    { connection: "cloud", sql: "select 2 as y", startLine: 5, endLine: 7 },
+  ]);
+});
+
+test("findBlocks respects longer fences around inner backticks", () => {
+  const blocks = findBlocks(
+    [
+      "````duckdb",
+      "select '```' as fence_text",
+      "```",
+      "select 2",
+      "````",
+    ].join("\n"),
+  );
+
+  assert.equal(blocks.length, 1);
+  assert.equal(blocks[0].sql, "select '```' as fence_text\n```\nselect 2");
+  assert.equal(blocks[0].endLine, 4);
+});
+
+test("writeSentinelAfterBlock inserts a frozen result after a block", () => {
+  const content = ["before", "```duckdb", "select 1", "```", "after"].join("\n");
+  const block = findBlocks(content)[0];
+
+  assert.equal(
+    writeSentinelAfterBlock(content, block, "<!-- md:cache hash=x -->\n\nresult\n\n<!-- md:cache-end -->"),
+    [
+      "before",
+      "```duckdb",
+      "select 1",
+      "```",
+      "",
+      "<!-- md:cache hash=x -->",
+      "",
+      "result",
+      "",
+      "<!-- md:cache-end -->",
+      "",
+      "after",
+    ].join("\n"),
+  );
+});
+
+test("writeSentinelAfterBlock replaces an existing frozen result", () => {
+  const content = [
+    "```duckdb",
+    "select 1",
+    "```",
+    "",
+    "<!-- md:cache hash=old -->",
+    "",
+    "old",
+    "",
+    "<!-- md:cache-end -->",
+    "",
+    "after",
+  ].join("\n");
+  const block = findBlocks(content)[0];
+
+  const updated = writeSentinelAfterBlock(
+    content,
+    block,
+    "<!-- md:cache hash=new -->\n\nnew\n\n<!-- md:cache-end -->",
+  );
+
+  assert.match(updated, /hash=new/);
+  assert.doesNotMatch(updated, /hash=old|old/);
+  assert.match(updated, /\nafter$/);
+});

--- a/test/runtime-values.test.ts
+++ b/test/runtime-values.test.ts
@@ -1,0 +1,24 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { normalizeValue } from "../src/runtime";
+
+test("normalizeValue converts non-JSON primitives and nested values", () => {
+  assert.equal(normalizeValue(42n), "42");
+  assert.equal(normalizeValue(new Uint8Array([1, 2, 3])), "<3 bytes>");
+  assert.deepEqual(normalizeValue([1n, null]), ["1", null]);
+  assert.deepEqual(normalizeValue({ id: 1n, nested: { ok: true } }), {
+    id: "1",
+    nested: { ok: true },
+  });
+});
+
+test("normalizeValue uses custom DuckDB value stringification", () => {
+  const value = {
+    micros: 123n,
+    toString() {
+      return "00:00:00.000123";
+    },
+  };
+
+  assert.equal(normalizeValue(value), "00:00:00.000123");
+});

--- a/test/schedule-path.test.ts
+++ b/test/schedule-path.test.ts
@@ -1,0 +1,25 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { shortPathLabel } from "../src/path";
+import { isOverdue } from "../src/schedule";
+
+test("isOverdue treats missing and invalid timestamps as due", () => {
+  assert.equal(isOverdue("daily", null, Date.UTC(2026, 4, 4)), true);
+  assert.equal(isOverdue("daily", "not a date", Date.UTC(2026, 4, 4)), true);
+});
+
+test("isOverdue compares cadence against a provided clock", () => {
+  const now = Date.UTC(2026, 4, 4, 12);
+
+  assert.equal(isOverdue("daily", new Date(now - 24 * 60 * 60 * 1000).toISOString(), now), true);
+  assert.equal(isOverdue("daily", new Date(now - 23 * 60 * 60 * 1000).toISOString(), now), false);
+  assert.equal(isOverdue("weekly", new Date(now - 7 * 24 * 60 * 60 * 1000).toISOString(), now), true);
+});
+
+test("shortPathLabel keeps badges compact", () => {
+  assert.equal(shortPathLabel(""), ":memory:");
+  assert.equal(shortPathLabel(":memory:"), ":memory:");
+  assert.equal(shortPathLabel("/Users/me/data.duckdb"), "data.duckdb");
+  assert.equal(shortPathLabel("C:\\Users\\me\\data.duckdb"), "data.duckdb");
+  assert.equal(shortPathLabel("opfs://notes.duckdb"), "notes.duckdb");
+});

--- a/test/table.test.ts
+++ b/test/table.test.ts
@@ -1,0 +1,54 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { escapeCell, normalizedRowCap, renderMarkdownTable, simpleHash } from "../src/table";
+
+test("escapeCell produces markdown-safe table cells", () => {
+  assert.equal(escapeCell("a|b\nc\\d\r"), "a\\|b c\\\\d");
+  assert.equal(escapeCell(null), "");
+  assert.equal(escapeCell({ nested: true }), "{\"nested\":true}");
+});
+
+test("normalizedRowCap falls back and clamps large values", () => {
+  assert.equal(normalizedRowCap(0), 100);
+  assert.equal(normalizedRowCap(Number.NaN), 100);
+  assert.equal(normalizedRowCap(2.8), 2);
+  assert.equal(normalizedRowCap(20000), 10000);
+});
+
+test("renderMarkdownTable includes connection-aware hash and escaped headers", () => {
+  const sql = "select 1 as \"a|b\"";
+  const rendered = renderMarkdownTable(
+    [{ "a|b": "x|y" }],
+    ["a|b"],
+    sql,
+    "local",
+    100,
+  );
+
+  assert.match(rendered, new RegExp(`hash=${simpleHash(`local\n${sql}`)}`));
+  assert.match(rendered, /conn=local/);
+  assert.match(rendered, /\| a\\\|b \|/);
+  assert.match(rendered, /\| x\\\|y \|/);
+});
+
+test("renderMarkdownTable keeps schema visible for zero-row results", () => {
+  const rendered = renderMarkdownTable([], ["name", "count"], "select * from empty", "cloud", 100);
+
+  assert.match(rendered, /\| name \| count \|/);
+  assert.match(rendered, /> 0 rows/);
+});
+
+test("renderMarkdownTable truncates rendered rows at the row cap", () => {
+  const rendered = renderMarkdownTable(
+    [{ x: 1 }, { x: 2 }, { x: 3 }],
+    ["x"],
+    "select x from t",
+    "local",
+    2,
+  );
+
+  assert.match(rendered, /\| 1 \|/);
+  assert.match(rendered, /\| 2 \|/);
+  assert.doesNotMatch(rendered, /\| 3 \|/);
+  assert.match(rendered, /1 more rows hidden \(cap 2\)/);
+});


### PR DESCRIPTION
## Summary
- serialize runtime initialization and query execution per connection
- guard refresh/freeze writes so newer note edits are not overwritten
- improve fenced-block parsing, result normalization, and zero-row schema handling
- move block styling to styles.css and add settings connection tests

## Verification
- npx tsc --noEmit
- npm run build
- git diff --check