### PR TITLE
Feedback batch: cell truncation, stale-cache UX, streaming runtime, schedule maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ From the command palette:
 - **Refresh all queries in this note**, re-runs every block in the current note.
 - **Refresh query at cursor**, re-runs and re-freezes only the block the cursor is on. Bind a hotkey under Settings → Hotkeys for fast vim-mode iteration.
 - **Freeze query at cursor**, alias of "Refresh query at cursor" — kept for users who think of it as the first-time freeze action.
+- **Clear frozen result at cursor**, removes the frozen sentinel block below the SQL block at the cursor (matching the Clear button shown in the rendered panel when a frozen result is present).
 - **Reset DuckDB/MotherDuck connections**, drops both connections; useful after changing the path or token.
 
 ## Settings

--- a/README.md
+++ b/README.md
@@ -1,8 +1,24 @@
 # DuckDB & MotherDuck for Obsidian
 
-Run DuckDB SQL directly inside your notes. Freeze the results as a plain markdown table so both you and any agent that reads the vault see `query + result` as one document.
+Bring **external data** into your Obsidian notes via DuckDB SQL, then freeze the results as a plain markdown table so you and any agent reading the vault see `query + result` as one document.
 
 Works entirely offline with local DuckDB WASM. Add a MotherDuck token to query your cloud data alongside, picking per code block which connection to use.
+
+## Why this and not Dataview?
+
+Dataview is the go-to plugin for querying *the vault itself* — your frontmatter, tags, and links across notes. This plugin solves the opposite problem: pulling **external data** (CSV, Parquet, JSON, Excel, Iceberg, Delta, geospatial files, plus your MotherDuck cloud) into a note via DuckDB SQL, and joining across them when you want.
+
+- Use **Dataview** for "list every note tagged #project, sorted by created date."
+- Use **this** for "the latest revenue numbers from my warehouse, joined with a local expenses CSV."
+
+Output is regular markdown wrapped in sentinel comments — so it diffs cleanly in git, renders in any editor (Neovim, VS Code, mobile previews), and stays readable to agents reading the vault.
+
+## When to use it
+
+- Embedding live numbers in a blog draft (e.g. `SELECT count(*) FROM read_parquet('events.parquet')`).
+- Quick exploration of a CSV/Parquet/Excel file in your data folder without leaving Obsidian.
+- Snapshotting a MotherDuck query into a weekly report note (with [scheduled refresh](#scheduled-refresh)).
+- Joining a local file (e.g. expenses CSV) with cloud tables in MotherDuck.
 
 ## What it does
 
@@ -29,6 +45,8 @@ SELECT brand, SUM(revenue) FROM sales GROUP BY 1 ORDER BY 2 DESC LIMIT 10
 ````
 
 The sentinel carries a query hash, connection, timestamp, and row count. Refresh/freeze replaces the sentinel block below the query.
+
+The frozen output is regular markdown — open the same note in Neovim, VS Code, or `cat`, and you see the table inline with the query. No custom rendering required, and any agent skimming the vault sees both the question and its answer as one document.
 
 ## Connections
 
@@ -72,9 +90,21 @@ Create code blocks tagged with the connection you want:
 SELECT 42 AS answer, now() AS ts
 ```
 
+```duckdb
+-- read a Parquet/CSV/JSON file from disk
+SELECT category, SUM(amount) AS total
+FROM read_csv('/Users/you/data/expenses.csv')
+GROUP BY 1
+ORDER BY total DESC
+LIMIT 5
+```
+
 ```motherduck
--- runs against MotherDuck (needs a token in plugin settings)
-SELECT current_database(), current_timestamp
+-- query MotherDuck and join with a local CSV in the same SQL
+SELECT s.region, s.revenue, e.amount AS expense
+FROM sales s
+LEFT JOIN read_csv('/Users/you/data/expenses.csv') e USING (region)
+ORDER BY s.revenue DESC
 ```
 ````
 
@@ -83,7 +113,8 @@ In reading mode each block shows its connection badge (`DuckDB :memory:` or `Mot
 From the command palette:
 
 - **Refresh all queries in this note**, re-runs every block in the current note.
-- **Freeze query at cursor**, freezes the block the cursor is on.
+- **Refresh query at cursor**, re-runs and re-freezes only the block the cursor is on. Bind a hotkey under Settings → Hotkeys for fast vim-mode iteration.
+- **Freeze query at cursor**, alias of "Refresh query at cursor" — kept for users who think of it as the first-time freeze action.
 - **Reset DuckDB/MotherDuck connections**, drops both connections; useful after changing the path or token.
 
 ## Settings
@@ -94,6 +125,7 @@ From the command palette:
 - **MotherDuck → Token**: optional. Stored plaintext in the plugin's `data.json` (see *Security* below). Prefer a [service account token](https://motherduck.com/docs/key-tasks/service-accounts-guide/create-and-configure-service-accounts/) for scoped, individually revocable access; or a [personal access token](https://motherduck.com/docs/key-tasks/authenticating-and-connecting-to-motherduck/authenticating-to-motherduck/#authentication-using-an-access-token) for quick experimentation.
 - **Scheduled refresh**: see the next section.
 - **General → Row cap**: max rows rendered inline or written into a frozen table. A truncation notice is appended if exceeded.
+- **General → Cell character cap**: max characters per cell in rendered and frozen tables; longer values are truncated with an ellipsis. Hover a truncated cell in the live result to see the full value. Default `80`.
 
 ## Scheduled refresh
 
@@ -115,7 +147,7 @@ The settings page also has:
 
 ## Agent trigger
 
-Both the human button and the agent flow share the same code path. From a shell (with the [Obsidian CLI](https://github.com/Yakitrak/obsidian-cli) installed):
+Both the human button and the agent flow share the same code path. From a shell with the [official Obsidian CLI](https://obsidian.md/help/cli) installed:
 
 ```sh
 obsidian eval code="app.plugins.getPlugin('duckdb-motherduck').api.refreshFile('path/to/note.md')"

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ From the command palette:
 - **DuckDB → Path to local DuckDB file**: `:memory:` (default), an OPFS bare filename, or an absolute file path. See *Connections* above.
 - **MotherDuck → Token**: optional. Stored plaintext in the plugin's `data.json` (see *Security* below). Prefer a [service account token](https://motherduck.com/docs/key-tasks/service-accounts-guide/create-and-configure-service-accounts/) for scoped, individually revocable access; or a [personal access token](https://motherduck.com/docs/key-tasks/authenticating-and-connecting-to-motherduck/authenticating-to-motherduck/#authentication-using-an-access-token) for quick experimentation.
 - **Scheduled refresh**: see the next section.
-- **General → Row cap**: max rows rendered inline or written into a frozen table. A truncation notice is appended if exceeded.
+- **General → Row cap**: max rows rendered inline or written into a frozen table. The runtime stops scanning at `rowCap + 1` rows and discards the rest, so heavy queries (`FROM 'huge.csv'`) don't materialize 40k rows in WASM heap just to throw 39 900 of them away. A truncation notice is appended if more rows existed.
 - **General → Cell character cap**: max characters per cell in rendered and frozen tables; longer values are truncated with an ellipsis. Hover a truncated cell in the live result to see the full value. Default `80`.
 
 ## Scheduled refresh
@@ -140,6 +140,10 @@ duckdb-motherduck-refresh-last: 2026-05-04T10:30:00Z   # plugin-managed
 ```
 
 While Obsidian is running and the **Auto-refresh scheduled notes** toggle is on, the plugin sweeps once an hour. Notes whose `last - now` exceeds their cadence get their frozen tables re-materialized. The active editor is skipped to avoid stomping in-progress edits.
+
+After each sweep finishes, if **Reset connections after each scheduled refresh** is enabled (default on), the plugin terminates the DuckDB and MotherDuck WASM workers to free memory. The next interactive query pays a ~1–2 s init cost; in exchange, you don't carry materialized result sets between sweeps.
+
+If a note errors three sweeps in a row with **every** block failing (zero blocks refreshed, errors recorded), the plugin auto-strips its `duckdb-motherduck-refresh` frontmatter so the hourly sweep stops poking it. Partial failures (some blocks succeed, some error) do **not** count — a working block keeps the schedule alive. Auto-unschedule events are written to the activity log.
 
 The settings page also has:
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ From the command palette:
 - **Refresh all queries in this note**, re-runs every block in the current note.
 - **Refresh query at cursor**, re-runs and re-freezes only the block the cursor is on. Bind a hotkey under Settings → Hotkeys for fast vim-mode iteration.
 - **Freeze query at cursor**, alias of "Refresh query at cursor" — kept for users who think of it as the first-time freeze action.
-- **Clear frozen result at cursor**, removes the frozen sentinel block below the SQL block at the cursor (matching the Clear button shown in the rendered panel when a frozen result is present).
+- **Clear freeze at cursor**, removes the frozen result below the SQL block at the cursor (matching the **Clear freeze** button shown in the rendered panel when a frozen result is present).
 - **Reset DuckDB/MotherDuck connections**, drops both connections; useful after changing the path or token.
 
 ## Settings

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ While Obsidian is running and the **Auto-refresh scheduled notes** toggle is on,
 The settings page also has:
 
 - A **Refresh now** button: forces a sweep of *every note in the vault that has a SQL block*, regardless of cadence or frontmatter opt-in. Useful before reading a dashboard, or for one-shot refreshes.
+- An **Unschedule all** button: strips `duckdb-motherduck-refresh` (and the plugin-managed `-last` timestamp) from every note's frontmatter. Use to bulk-disable auto-refresh after experimenting, or to free up the hourly sweep before running heavy queries.
 - An **Activity log** showing the last 100 refresh attempts (timestamp, trigger, path, blocks refreshed, first error message if any). Click a path to open the note. **Clear log** wipes history.
 
 ## Agent trigger

--- a/main.ts
+++ b/main.ts
@@ -42,6 +42,23 @@ export default class MotherDuckPlugin extends Plugin {
       renderQueryBlock(this, "cloud", src, el, ctx),
     );
 
+    this.registerMarkdownPostProcessor((el, ctx) => {
+      const info = ctx.getSectionInfo(el);
+      if (!info) return;
+      const lines = info.text.split("\n");
+      for (let i = 0; i < lines.length; i++) {
+        if (!/<!-- md:cache hash=/.test(lines[i])) continue;
+        let j = i + 1;
+        while (j < lines.length && !/<!-- md:cache-end -->/.test(lines[j])) j++;
+        if (j >= lines.length) break;
+        if (info.lineStart >= i && info.lineEnd <= j) {
+          el.addClass("motherduck-cache-block");
+          return;
+        }
+        i = j;
+      }
+    });
+
     this.addCommand({
       id: "refresh-current-note",
       name: "Refresh all queries in this note",
@@ -59,6 +76,20 @@ export default class MotherDuckPlugin extends Plugin {
     this.addCommand({
       id: "freeze-at-cursor",
       name: "Freeze query at cursor",
+      editorCallback: async (editor, view) => {
+        if (!(view instanceof MarkdownView) || !view.file) return;
+        try {
+          const msg = await this.freezeAtCursor(view.file, editor.getCursor().line);
+          new Notice(msg);
+        } catch (e) {
+          new Notice(`error: ${e instanceof Error ? e.message : String(e)}`);
+        }
+      },
+    });
+
+    this.addCommand({
+      id: "refresh-at-cursor",
+      name: "Refresh query at cursor",
       editorCallback: async (editor, view) => {
         if (!(view instanceof MarkdownView) || !view.file) return;
         try {
@@ -183,7 +214,7 @@ export default class MotherDuckPlugin extends Plugin {
       if (!hit) throw new Error("no ```duckdb or ```motherduck block at cursor");
       const newContent = await this.freezeBlock(content, hit);
       await this.modifyIfUnchanged(file, content, newContent);
-      return "Froze 1 block";
+      return "Refreshed 1 block";
     });
   }
 
@@ -240,6 +271,7 @@ export default class MotherDuckPlugin extends Plugin {
       block.sql,
       block.connection,
       this.settings.rowCap,
+      this.settings.cellCharCap,
     );
     return writeSentinelAfterBlock(content, block, mdTable);
   }

--- a/main.ts
+++ b/main.ts
@@ -1,6 +1,11 @@
 import { MarkdownPostProcessorContext, MarkdownView, Notice, Plugin, TFile } from "obsidian";
 import { FileLock } from "./src/file-lock";
-import { findBlocks, writeSentinelAfterBlock, type FencedBlock } from "./src/markdown";
+import {
+  findBlocks,
+  removeSentinelAfterBlock,
+  writeSentinelAfterBlock,
+  type FencedBlock,
+} from "./src/markdown";
 import { renderQueryBlock } from "./src/query-block";
 import { RuntimeManager } from "./src/runtime/manager";
 import { isOverdue } from "./src/schedule";
@@ -94,6 +99,20 @@ export default class MotherDuckPlugin extends Plugin {
         if (!(view instanceof MarkdownView) || !view.file) return;
         try {
           const msg = await this.freezeAtCursor(view.file, editor.getCursor().line);
+          new Notice(msg);
+        } catch (e) {
+          new Notice(`error: ${e instanceof Error ? e.message : String(e)}`);
+        }
+      },
+    });
+
+    this.addCommand({
+      id: "clear-freeze-at-cursor",
+      name: "Clear frozen result at cursor",
+      editorCallback: async (editor, view) => {
+        if (!(view instanceof MarkdownView) || !view.file) return;
+        try {
+          const msg = await this.clearFreezeAtCursor(view.file, editor.getCursor().line);
           new Notice(msg);
         } catch (e) {
           new Notice(`error: ${e instanceof Error ? e.message : String(e)}`);
@@ -215,6 +234,40 @@ export default class MotherDuckPlugin extends Plugin {
       const newContent = await this.freezeBlock(content, hit);
       await this.modifyIfUnchanged(file, content, newContent);
       return "Refreshed 1 block";
+    });
+  }
+
+  async clearFreezeAtCursor(file: TFile, cursorLine: number): Promise<string> {
+    return this.fileLocks.run(file.path, async () => {
+      const content = await this.app.vault.read(file);
+      const blocks = findBlocks(content);
+      const hit = blocks.find((b) => cursorLine >= b.startLine && cursorLine <= b.endLine);
+      if (!hit) throw new Error("no ```duckdb or ```motherduck block at cursor");
+      const newContent = removeSentinelAfterBlock(content, hit);
+      if (newContent === content) return "no frozen result to clear";
+      await this.modifyIfUnchanged(file, content, newContent);
+      return "Cleared 1 frozen result";
+    });
+  }
+
+  async clearRenderedBlock(
+    ctx: MarkdownPostProcessorContext,
+    el: HTMLElement,
+  ): Promise<void> {
+    const file = this.app.vault.getAbstractFileByPath(ctx.sourcePath);
+    if (!(file instanceof TFile)) throw new Error(`not a file: ${ctx.sourcePath}`);
+
+    await this.fileLocks.run(file.path, async () => {
+      const info = ctx.getSectionInfo(el);
+      if (!info) throw new Error("cannot locate block position");
+      const content = await this.app.vault.read(file);
+      const block = findBlocks(content).find(
+        (candidate) => candidate.startLine === info.lineStart && candidate.endLine === info.lineEnd,
+      );
+      if (!block) throw new Error("block not found in file");
+      const newContent = removeSentinelAfterBlock(content, block);
+      if (newContent === content) return;
+      await this.modifyIfUnchanged(file, content, newContent);
     });
   }
 

--- a/main.ts
+++ b/main.ts
@@ -195,6 +195,24 @@ export default class MotherDuckPlugin extends Plugin {
     });
   }
 
+  async unscheduleAllNotes(): Promise<number> {
+    let count = 0;
+    for (const file of this.app.vault.getMarkdownFiles()) {
+      const fm = this.app.metadataCache.getFileCache(file)?.frontmatter;
+      if (!fm) continue;
+      if (
+        !("duckdb-motherduck-refresh" in fm) &&
+        !("duckdb-motherduck-refresh-last" in fm)
+      ) continue;
+      await this.app.fileManager.processFrontMatter(file, (fmEdit) => {
+        delete fmEdit["duckdb-motherduck-refresh"];
+        delete fmEdit["duckdb-motherduck-refresh-last"];
+      });
+      count++;
+    }
+    return count;
+  }
+
   async runManualSweep(): Promise<SweepResult> {
     const all = await this.discoverNotesWithBlocks();
     const optedIn = new Set(this.discoverScheduledNotes().map((c) => c.file.path));

--- a/main.ts
+++ b/main.ts
@@ -108,7 +108,7 @@ export default class MotherDuckPlugin extends Plugin {
 
     this.addCommand({
       id: "clear-freeze-at-cursor",
-      name: "Clear frozen result at cursor",
+      name: "Clear freeze at cursor",
       editorCallback: async (editor, view) => {
         if (!(view instanceof MarkdownView) || !view.file) return;
         try {

--- a/main.ts
+++ b/main.ts
@@ -8,10 +8,11 @@ import {
 } from "./src/markdown";
 import { renderQueryBlock } from "./src/query-block";
 import { RuntimeManager } from "./src/runtime/manager";
-import { isOverdue } from "./src/schedule";
+import { consecutiveAllErrorFailures, isOverdue } from "./src/schedule";
 import { SettingsTab } from "./src/settings-tab";
 import { renderMarkdownTable } from "./src/table";
 import {
+  AUTO_DISABLE_FAILURE_THRESHOLD,
   DEFAULTS,
   LOG_CAP,
   STARTUP_DELAY_MS,
@@ -158,8 +159,12 @@ export default class MotherDuckPlugin extends Plugin {
     await this.runtimeManager.reset(only);
   }
 
-  async runQuery(sql: string, connection: Connection): Promise<QueryRunResult> {
-    return this.runtimeManager.runQuery(sql, connection);
+  async runQuery(
+    sql: string,
+    connection: Connection,
+    rowCap?: number,
+  ): Promise<QueryRunResult> {
+    return this.runtimeManager.runQuery(sql, connection, rowCap);
   }
 
   startScheduler() {
@@ -187,12 +192,22 @@ export default class MotherDuckPlugin extends Plugin {
   }
 
   async runScheduledSweep(): Promise<SweepResult> {
-    return this.runSweepInternal({
+    const result = await this.runSweepInternal({
       trigger: "schedule",
       candidates: this.discoverScheduledNotes(),
       ignoreCadence: false,
       stampLastOnSuccess: true,
     });
+    // Free WASM workers between sweeps. Trade-off: the next interactive query
+    // pays ~1-2s of init cost. Big memory win for scheduled-heavy users.
+    if (this.settings.resetAfterSchedule && result.checked > 0) {
+      try {
+        await this.resetRuntimes();
+      } catch (e) {
+        console.error("[motherduck] auto-reset after sweep failed", e);
+      }
+    }
+    return result;
   }
 
   async unscheduleAllNotes(): Promise<number> {
@@ -335,7 +350,11 @@ export default class MotherDuckPlugin extends Plugin {
   }
 
   async freezeBlock(content: string, block: FencedBlock): Promise<string> {
-    const { rows, columns } = await this.runQuery(block.sql, block.connection);
+    const { rows, columns, truncated } = await this.runQuery(
+      block.sql,
+      block.connection,
+      this.settings.rowCap,
+    );
     const mdTable = renderMarkdownTable(
       rows,
       columns,
@@ -343,6 +362,7 @@ export default class MotherDuckPlugin extends Plugin {
       block.connection,
       this.settings.rowCap,
       this.settings.cellCharCap,
+      truncated,
     );
     return writeSentinelAfterBlock(content, block, mdTable);
   }
@@ -394,6 +414,9 @@ export default class MotherDuckPlugin extends Plugin {
           });
           if (result.errored > 0) errored++;
           else refreshed++;
+          if (opts.trigger === "schedule") {
+            await this.maybeAutoUnschedule(file);
+          }
         } catch (e) {
           const msg = e instanceof Error ? e.message : String(e);
           console.error(`[motherduck] sweep: refresh failed for ${file.path}:`, e);
@@ -406,6 +429,9 @@ export default class MotherDuckPlugin extends Plugin {
             errorMessage: msg,
           });
           errored++;
+          if (opts.trigger === "schedule") {
+            await this.maybeAutoUnschedule(file);
+          }
         }
       }
     } finally {
@@ -442,6 +468,39 @@ export default class MotherDuckPlugin extends Plugin {
       }
     }
     return out;
+  }
+
+  private async maybeAutoUnschedule(file: TFile): Promise<void> {
+    const count = consecutiveAllErrorFailures(this.settings.refreshLog, file.path);
+    if (count < AUTO_DISABLE_FAILURE_THRESHOLD) return;
+
+    const fm = this.app.metadataCache.getFileCache(file)?.frontmatter;
+    if (
+      !fm ||
+      (!("duckdb-motherduck-refresh" in fm) && !("duckdb-motherduck-refresh-last" in fm))
+    ) {
+      return;
+    }
+
+    try {
+      await this.app.fileManager.processFrontMatter(file, (fmEdit) => {
+        delete fmEdit["duckdb-motherduck-refresh"];
+        delete fmEdit["duckdb-motherduck-refresh-last"];
+      });
+      await this.appendLog({
+        ts: new Date().toISOString(),
+        path: file.path,
+        trigger: "schedule",
+        blocks: 0,
+        errored: 0,
+        errorMessage: `Auto-unscheduled after ${AUTO_DISABLE_FAILURE_THRESHOLD} consecutive failures`,
+      });
+      console.log(
+        `[motherduck] auto-unscheduled ${file.path} after ${count} consecutive failures`,
+      );
+    } catch (e) {
+      console.error("[motherduck] auto-unschedule failed", e);
+    }
   }
 
   private async appendLog(entry: RefreshLogEntry) {

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -76,3 +76,23 @@ export function findCacheHashAfterLine(content: string, lineEnd: number): string
   const m = lines[j].match(/<!-- md:cache hash=([0-9a-f]+)/);
   return m ? m[1] : null;
 }
+
+export function removeSentinelAfterBlock(content: string, block: FencedBlock): string {
+  const lines = content.split("\n");
+  const afterBlock = block.endLine + 1;
+  let j = afterBlock;
+
+  while (j < lines.length && lines[j].trim() === "") j++;
+  if (j >= lines.length || !/<!-- md:cache hash=/.test(lines[j])) return content;
+
+  let k = j;
+  while (k < lines.length && !/<!-- md:cache-end -->/.test(lines[k])) k++;
+  if (k >= lines.length) return content;
+
+  let cutEnd = k + 1;
+  while (cutEnd < lines.length && lines[cutEnd].trim() === "") cutEnd++;
+
+  const before = lines.slice(0, afterBlock).join("\n");
+  const rest = lines.slice(cutEnd).join("\n");
+  return rest ? `${before}\n\n${rest}` : `${before}\n`;
+}

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -67,3 +67,12 @@ export function writeSentinelAfterBlock(
 function escapeRegExp(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
+
+export function findCacheHashAfterLine(content: string, lineEnd: number): string | null {
+  const lines = content.split("\n");
+  let j = lineEnd + 1;
+  while (j < lines.length && lines[j].trim() === "") j++;
+  if (j >= lines.length) return null;
+  const m = lines[j].match(/<!-- md:cache hash=([0-9a-f]+)/);
+  return m ? m[1] : null;
+}

--- a/src/query-block.ts
+++ b/src/query-block.ts
@@ -15,6 +15,7 @@ export interface QueryBlockHost {
     sql: string,
     connection: Connection,
   ): Promise<void>;
+  clearRenderedBlock(ctx: MarkdownPostProcessorContext, el: HTMLElement): Promise<void>;
 }
 
 export function renderQueryBlock(
@@ -43,14 +44,12 @@ export function renderQueryBlock(
   }
 
   const info = ctx.getSectionInfo(el);
-  if (info) {
-    const cachedHash = findCacheHashAfterLine(info.text, info.lineEnd);
-    if (cachedHash && cachedHash !== simpleHash(`${connection}\n${sql}`)) {
-      const warn = badge.createEl("span", { cls: "motherduck-block__stale-warn" });
-      warn.title =
-        "The frozen result below was produced by a different query or connection. Run/Freeze to update it.";
-      warn.appendText("⚠ cache stale");
-    }
+  const cachedHash = info ? findCacheHashAfterLine(info.text, info.lineEnd) : null;
+  if (cachedHash && cachedHash !== simpleHash(`${connection}\n${sql}`)) {
+    const warn = badge.createEl("span", { cls: "motherduck-block__stale-warn" });
+    warn.title =
+      "The frozen result below was produced by a different query or connection. Run/Freeze to update it.";
+    warn.appendText("⚠ cache stale");
   }
 
   attachRefreshDropdown(host, badge, ctx);
@@ -71,6 +70,15 @@ export function renderQueryBlock(
   freezeBtn.appendText("Freeze");
   freezeBtn.title = "Run and freeze result below this block";
   freezeBtn.setAttr("aria-label", "Run and freeze result below this block");
+
+  let clearBtn: HTMLButtonElement | null = null;
+  if (cachedHash) {
+    clearBtn = btnRow.createEl("button", { cls: "motherduck-block__button" });
+    setIcon(clearBtn, "eraser");
+    clearBtn.appendText("Clear");
+    clearBtn.title = "Remove the frozen result below this block";
+    clearBtn.setAttr("aria-label", "Remove the frozen result below this block");
+  }
 
   const status = btnRow.createEl("span", { cls: "motherduck-block__status" });
   const resultEl = wrap.createDiv({ cls: "motherduck-block__result" });
@@ -109,13 +117,28 @@ export function renderQueryBlock(
     }
   });
 
+  if (clearBtn) {
+    clearBtn.addEventListener("click", async () => {
+      status.setText("clearing…");
+      setButtonsDisabled(true);
+      try {
+        await host.clearRenderedBlock(ctx, el);
+        status.setText("cleared ✓");
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        status.setText(`error: ${msg}`);
+        console.error("[motherduck] clear failed", e);
+      } finally {
+        setButtonsDisabled(false);
+      }
+    });
+  }
+
   function setButtonsDisabled(disabled: boolean) {
-    if (disabled) {
-      runBtn.setAttr("disabled", "true");
-      freezeBtn.setAttr("disabled", "true");
-    } else {
-      runBtn.removeAttribute("disabled");
-      freezeBtn.removeAttribute("disabled");
+    for (const btn of [runBtn, freezeBtn, clearBtn]) {
+      if (!btn) continue;
+      if (disabled) btn.setAttr("disabled", "true");
+      else btn.removeAttribute("disabled");
     }
   }
 }

--- a/src/query-block.ts
+++ b/src/query-block.ts
@@ -72,7 +72,7 @@ export function renderQueryBlock(
       const { rows, columns } = await host.runQuery(sql, connection);
       const dt = Math.round(performance.now() - t0);
       status.setText(`${rows.length} row(s) · ${dt} ms`);
-      renderDomTable(resultEl, rows, columns, host.settings.rowCap);
+      renderDomTable(resultEl, rows, columns, host.settings.rowCap, host.settings.cellCharCap);
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       status.setText("error");

--- a/src/query-block.ts
+++ b/src/query-block.ts
@@ -1,7 +1,8 @@
 import { App, MarkdownPostProcessorContext, Notice, TFile, setIcon } from "obsidian";
 import { DUCKDB_ICON, MOTHERDUCK_ICON } from "./icons";
+import { findCacheHashAfterLine } from "./markdown";
 import { shortPathLabel } from "./path";
-import { renderDomTable } from "./table";
+import { renderDomTable, simpleHash } from "./table";
 import type { Connection, QueryRunResult, Settings } from "./types";
 
 export interface QueryBlockHost {
@@ -39,6 +40,17 @@ export function renderQueryBlock(
   } else {
     badge.createEl("span", { text: "DuckDB " });
     badge.createEl("code", { text: shortPathLabel(host.settings.dbPath) });
+  }
+
+  const info = ctx.getSectionInfo(el);
+  if (info) {
+    const cachedHash = findCacheHashAfterLine(info.text, info.lineEnd);
+    if (cachedHash && cachedHash !== simpleHash(`${connection}\n${sql}`)) {
+      const warn = badge.createEl("span", { cls: "motherduck-block__stale-warn" });
+      warn.title =
+        "The frozen result below was produced by a different query or connection. Run/Freeze to update it.";
+      warn.appendText("⚠ cache stale");
+    }
   }
 
   attachRefreshDropdown(host, badge, ctx);

--- a/src/query-block.ts
+++ b/src/query-block.ts
@@ -75,7 +75,7 @@ export function renderQueryBlock(
   if (cachedHash) {
     clearBtn = btnRow.createEl("button", { cls: "motherduck-block__button" });
     setIcon(clearBtn, "eraser");
-    clearBtn.appendText("Clear");
+    clearBtn.appendText("Clear freeze");
     clearBtn.title = "Remove the frozen result below this block";
     clearBtn.setAttr("aria-label", "Remove the frozen result below this block");
   }

--- a/src/query-block.ts
+++ b/src/query-block.ts
@@ -8,7 +8,7 @@ import type { Connection, QueryRunResult, Settings } from "./types";
 export interface QueryBlockHost {
   app: App;
   settings: Settings;
-  runQuery(sql: string, connection: Connection): Promise<QueryRunResult>;
+  runQuery(sql: string, connection: Connection, rowCap?: number): Promise<QueryRunResult>;
   freezeRenderedBlock(
     ctx: MarkdownPostProcessorContext,
     el: HTMLElement,
@@ -89,10 +89,22 @@ export function renderQueryBlock(
     setButtonsDisabled(true);
     const t0 = performance.now();
     try {
-      const { rows, columns } = await host.runQuery(sql, connection);
+      const { rows, columns, truncated } = await host.runQuery(
+        sql,
+        connection,
+        host.settings.rowCap,
+      );
       const dt = Math.round(performance.now() - t0);
-      status.setText(`${rows.length} row(s) · ${dt} ms`);
-      renderDomTable(resultEl, rows, columns, host.settings.rowCap, host.settings.cellCharCap);
+      const rowsLabel = truncated ? `${rows.length}+ row(s)` : `${rows.length} row(s)`;
+      status.setText(`${rowsLabel} · ${dt} ms`);
+      renderDomTable(
+        resultEl,
+        rows,
+        columns,
+        host.settings.rowCap,
+        host.settings.cellCharCap,
+        truncated,
+      );
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       status.setText("error");

--- a/src/runtime/duckdb.ts
+++ b/src/runtime/duckdb.ts
@@ -138,16 +138,52 @@ export class DuckDBWasmRuntime implements Runtime {
     this.conn = await this.db.connect();
   }
 
-  async runQuery(sql: string): Promise<QueryResult> {
+  async runQuery(sql: string, rowCap?: number): Promise<QueryResult> {
     if (!this.conn) await this.init();
-    const table = await this.conn!.query(sql);
-    const columns = table.schema.fields.map((f) => f.name);
-    const rows: Row[] = table.toArray().map((r: Record<string, unknown>) => {
-      const obj: Row = {};
-      for (const c of columns) obj[c] = normalizeValue(r[c]);
-      return obj;
-    });
-    return { rows, columns };
+
+    if (rowCap === undefined) {
+      const table = await this.conn!.query(sql);
+      const columns = table.schema.fields.map((f) => f.name);
+      const rows: Row[] = table.toArray().map((r: Record<string, unknown>) => {
+        const obj: Row = {};
+        for (const c of columns) obj[c] = normalizeValue(r[c]);
+        return obj;
+      });
+      return { rows, columns, truncated: false };
+    }
+
+    // Streaming path: read batches until we have rowCap+1 rows, then cancel
+    // the underlying stream so DuckDB stops scanning. For pipeline-friendly
+    // queries (e.g. `FROM 'huge.csv'`) this avoids materializing the full
+    // result in WASM heap or in JS.
+    const limit = rowCap + 1;
+    const stream = await this.conn!.send(sql);
+    const columns = stream.schema.fields.map((f) => f.name);
+    const rows: Row[] = [];
+
+    try {
+      while (rows.length < limit) {
+        const next = await stream.next();
+        if (next.done) break;
+        const batchRows = next.value.toArray() as Record<string, unknown>[];
+        for (const r of batchRows) {
+          if (rows.length >= limit) break;
+          const obj: Row = {};
+          for (const c of columns) obj[c] = normalizeValue(r[c]);
+          rows.push(obj);
+        }
+      }
+    } finally {
+      try {
+        await stream.cancel();
+      } catch (e) {
+        console.error("[motherduck] stream cancel failed", e);
+      }
+    }
+
+    const truncated = rows.length > rowCap;
+    if (truncated) rows.length = rowCap;
+    return { rows, columns, truncated };
   }
 
   async close(): Promise<void> {

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -3,11 +3,24 @@ export type Row = Record<string, unknown>;
 export interface QueryResult {
   rows: Row[];
   columns: string[];
+  /**
+   * True when the query produced more rows than the caller asked for via
+   * `rowCap`. The runtime stops reading at `rowCap + 1` and trims to `rowCap`,
+   * so the precise total is unknown. False (or absent) means we materialized
+   * the entire result and `rows.length` is the true total.
+   */
+  truncated: boolean;
 }
 
 export interface Runtime {
   init(): Promise<void>;
-  runQuery(sql: string): Promise<QueryResult>;
+  /**
+   * Run `sql` and return rows + columns. If `rowCap` is set, the runtime stops
+   * reading after `rowCap + 1` rows, trims to `rowCap`, and returns
+   * `truncated: true`. If `rowCap` is undefined, the entire result is
+   * materialized (legacy behavior, used for the public plugin API).
+   */
+  runQuery(sql: string, rowCap?: number): Promise<QueryResult>;
   close(): Promise<void>;
   label(): string;
 }

--- a/src/runtime/manager.ts
+++ b/src/runtime/manager.ts
@@ -45,10 +45,14 @@ export class RuntimeManager {
     }
   }
 
-  async runQuery(sql: string, connection: Connection): Promise<QueryRunResult> {
+  async runQuery(
+    sql: string,
+    connection: Connection,
+    rowCap?: number,
+  ): Promise<QueryRunResult> {
     return this.enqueueQuery(connection, async () => {
       const rt = await this.getRuntime(connection);
-      return rt.runQuery(sql);
+      return rt.runQuery(sql, rowCap);
     });
   }
 

--- a/src/runtime/motherduck.ts
+++ b/src/runtime/motherduck.ts
@@ -20,20 +20,45 @@ export class MotherDuckRuntime implements Runtime {
     await this.connection.isInitialized();
   }
 
-  async runQuery(sql: string): Promise<QueryResult> {
+  async runQuery(sql: string, rowCap?: number): Promise<QueryResult> {
     if (!this.connection) await this.init();
-    const result = await this.connection!.safeEvaluateQuery(sql);
+
+    if (rowCap === undefined) {
+      const result = await this.connection!.safeEvaluateQuery(sql);
+      if (result.status !== "success") {
+        const err = (result as { err?: { message?: string } }).err;
+        throw new Error(err?.message ?? JSON.stringify(err));
+      }
+      const columns = [...result.result.data.deduplicatedColumnNames()];
+      const rows = result.result.data.toRows().map((row) => {
+        const out: Row = {};
+        for (const column of columns) out[column] = normalizeValue(row[column]);
+        return out;
+      });
+      return { rows, columns, truncated: false };
+    }
+
+    // Streaming path: dataReader.readUntil(N) reads in batches of ~2048 rows
+    // until at least N rows are buffered. We ask for rowCap+1 to detect
+    // truncation, then trim to rowCap.
+    const result = await this.connection!.safeEvaluateStreamingQuery(sql);
     if (result.status !== "success") {
       const err = (result as { err?: { message?: string } }).err;
       throw new Error(err?.message ?? JSON.stringify(err));
     }
-    const columns = [...result.result.data.deduplicatedColumnNames()];
-    const rows = result.result.data.toRows().map((row) => {
+    const reader = result.result.dataReader;
+    await reader.readUntil(rowCap + 1);
+
+    const columns = [...reader.deduplicatedColumnNames()];
+    const allRows = reader.toRows();
+    const truncated = allRows.length > rowCap;
+    const sliced = truncated ? allRows.slice(0, rowCap) : allRows;
+    const rows = sliced.map((row) => {
       const out: Row = {};
       for (const column of columns) out[column] = normalizeValue(row[column]);
       return out;
     });
-    return { rows, columns };
+    return { rows, columns, truncated };
   }
 
   async close(): Promise<void> {

--- a/src/schedule.ts
+++ b/src/schedule.ts
@@ -1,4 +1,4 @@
-import { CADENCE_MS, type Cadence } from "./types";
+import { CADENCE_MS, type Cadence, type RefreshLogEntry } from "./types";
 
 export function isOverdue(cadence: Cadence, lastRefresh: string | null, now = Date.now()): boolean {
   if (!lastRefresh) return true;
@@ -13,4 +13,35 @@ export function formatLogTimestamp(iso: string): string {
   } catch {
     return iso;
   }
+}
+
+/**
+ * "All-error failure" = the refresh attempt produced zero successful blocks
+ * AND signaled an error. Either every block in the note errored, or the file
+ * couldn't be processed at all (caught at the outer try/catch).
+ *
+ * Partial-failure entries (some blocks refreshed, some errored) are NOT
+ * counted — we don't want to auto-unschedule a note where one block is
+ * working fine just because a sibling block is broken.
+ */
+export function isAllErrorFailure(entry: RefreshLogEntry): boolean {
+  return entry.blocks === 0 && (entry.errored > 0 || !!entry.errorMessage);
+}
+
+/**
+ * Counts consecutive all-error log entries for `path` from newest backward,
+ * stopping as soon as a success (or partial success) is encountered. Log is
+ * expected newest-first (we unshift on append).
+ */
+export function consecutiveAllErrorFailures(
+  log: ReadonlyArray<RefreshLogEntry>,
+  path: string,
+): number {
+  let count = 0;
+  for (const entry of log) {
+    if (entry.path !== path) continue;
+    if (!isAllErrorFailure(entry)) return count;
+    count++;
+  }
+  return count;
 }

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -12,6 +12,7 @@ export interface SettingsTabHost {
   startScheduler(): void;
   stopScheduler(): void;
   runManualSweep(): Promise<SweepResult>;
+  unscheduleAllNotes(): Promise<number>;
 }
 
 export class SettingsTab extends PluginSettingTab {
@@ -189,6 +190,29 @@ export class SettingsTab extends PluginSettingTab {
           } finally {
             b.setDisabled(false);
             b.setButtonText("Refresh now");
+            this.display();
+          }
+        }),
+      );
+
+    new Setting(this.containerEl)
+      .setName("Unschedule all notes")
+      .setDesc(
+        "Strips duckdb-motherduck-refresh and duckdb-motherduck-refresh-last from every note's frontmatter. Use to bulk-disable auto-refresh without touching each note individually.",
+      )
+      .addButton((b) =>
+        b.setButtonText("Unschedule all").onClick(async () => {
+          b.setDisabled(true);
+          b.setButtonText("Unscheduling...");
+          try {
+            const n = await this.plugin.unscheduleAllNotes();
+            new Notice(`Unscheduled ${n} note(s)`);
+          } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            new Notice(`error: ${msg}`);
+          } finally {
+            b.setDisabled(false);
+            b.setButtonText("Unschedule all");
             this.display();
           }
         }),

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -213,6 +213,24 @@ export class SettingsTab extends PluginSettingTab {
             }
           }),
       );
+
+    new Setting(this.containerEl)
+      .setName("Cell character cap")
+      .setDesc(
+        "Max characters per cell in rendered and frozen tables; longer values are truncated with an ellipsis. Hover a truncated cell in the live result to see the full value.",
+      )
+      .addText((t) =>
+        t
+          .setPlaceholder("80")
+          .setValue(String(this.plugin.settings.cellCharCap))
+          .onChange(async (v) => {
+            const n = parseInt(v, 10);
+            if (!Number.isNaN(n) && n > 0) {
+              this.plugin.settings.cellCharCap = Math.min(Math.floor(n), 10000);
+              await this.plugin.saveSettings();
+            }
+          }),
+      );
   }
 
   private renderActivityLog() {

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -8,7 +8,7 @@ export interface SettingsTabHost {
   settings: Settings;
   saveSettings(): Promise<void>;
   resetRuntimes(only?: Connection): Promise<void>;
-  runQuery(sql: string, connection: Connection): Promise<QueryRunResult>;
+  runQuery(sql: string, connection: Connection, rowCap?: number): Promise<QueryRunResult>;
   startScheduler(): void;
   stopScheduler(): void;
   runManualSweep(): Promise<SweepResult>;
@@ -169,6 +169,18 @@ export class SettingsTab extends PluginSettingTab {
           await this.plugin.saveSettings();
           if (v) this.plugin.startScheduler();
           else this.plugin.stopScheduler();
+        }),
+      );
+
+    new Setting(this.containerEl)
+      .setName("Reset connections after each scheduled refresh")
+      .setDesc(
+        "Frees WASM worker memory once the hourly sweep finishes. Trade-off: the next interactive query pays ~1-2s of init cost. Recommended on for memory-heavy queries.",
+      )
+      .addToggle((t) =>
+        t.setValue(this.plugin.settings.resetAfterSchedule).onChange(async (v) => {
+          this.plugin.settings.resetAfterSchedule = v;
+          await this.plugin.saveSettings();
         }),
       );
 

--- a/src/table.ts
+++ b/src/table.ts
@@ -31,6 +31,7 @@ export function renderMarkdownTable(
   connection: Connection,
   rowCap: number,
   cellCharCap: number = DEFAULTS.cellCharCap,
+  truncated: boolean = false,
 ): string {
   const hash = simpleHash(`${connection}\n${sql.trim()}`);
   const ts = new Date().toISOString();
@@ -38,7 +39,11 @@ export function renderMarkdownTable(
   const cap = normalizedRowCap(rowCap);
   const shown = rows.slice(0, cap);
 
-  const open = `<!-- md:cache hash=${hash} conn=${connection} ts=${ts} rows=${totalRows} -->`;
+  // When `truncated` is set, totalRows is the (capped) count we read, not the
+  // true total — DuckDB stopped scanning early. Mark the sentinel with `+` so
+  // the count is unambiguous.
+  const rowsAttr = truncated ? `${totalRows}+` : `${totalRows}`;
+  const open = `<!-- md:cache hash=${hash} conn=${connection} ts=${ts} rows=${rowsAttr} -->`;
   const close = "<!-- md:cache-end -->";
 
   if (columns.length === 0) {
@@ -51,10 +56,13 @@ export function renderMarkdownTable(
     (r) => "| " + columns.map((c) => escapeCell(r[c], cellCharCap)).join(" | ") + " |",
   );
   const emptyNotice = totalRows === 0 ? "\n\n> 0 rows" : "";
-  const truncated =
-    totalRows > cap ? `\n\n> … ${totalRows - cap} more rows hidden (cap ${cap})` : "";
+  const truncatedNotice = truncated
+    ? `\n\n> … more rows hidden (cap ${cap}; query stopped early)`
+    : totalRows > cap
+      ? `\n\n> … ${totalRows - cap} more rows hidden (cap ${cap})`
+      : "";
 
-  return `${open}\n\n${header}\n${sep}\n${body.join("\n")}${emptyNotice}${truncated}\n\n${close}`;
+  return `${open}\n\n${header}\n${sep}\n${body.join("\n")}${emptyNotice}${truncatedNotice}\n\n${close}`;
 }
 
 export function renderDomTable(
@@ -63,6 +71,7 @@ export function renderDomTable(
   columns: string[],
   rowCap: number,
   cellCharCap: number = DEFAULTS.cellCharCap,
+  truncated: boolean = false,
 ) {
   if (columns.length === 0) {
     parent.createEl("em", { text: "(0 rows)" });
@@ -97,7 +106,13 @@ export function renderDomTable(
     empty.style.marginTop = "4px";
   }
 
-  if (rows.length > cap) {
+  if (truncated) {
+    const more = parent.createEl("div", {
+      cls: "motherduck-muted",
+      text: `… more rows hidden (cap ${cap}; query stopped early)`,
+    });
+    more.style.marginTop = "4px";
+  } else if (rows.length > cap) {
     const more = parent.createEl("div", {
       cls: "motherduck-muted",
       text: `… ${rows.length - cap} more rows hidden (cap ${cap})`,

--- a/src/table.ts
+++ b/src/table.ts
@@ -8,9 +8,19 @@ export function simpleHash(s: string): string {
   return (h >>> 0).toString(16).padStart(8, "0");
 }
 
-export function escapeCell(v: unknown): string {
+export function stringifyCell(v: unknown): string {
   if (v === null || v === undefined) return "";
-  const s = typeof v === "object" ? JSON.stringify(v) : String(v);
+  return typeof v === "object" ? JSON.stringify(v) : String(v);
+}
+
+export function truncateString(s: string, charCap: number): string {
+  const cap = normalizedCellCharCap(charCap);
+  if (s.length <= cap) return s;
+  return s.slice(0, Math.max(1, cap - 1)) + "…";
+}
+
+export function escapeCell(v: unknown, charCap: number = DEFAULTS.cellCharCap): string {
+  const s = truncateString(stringifyCell(v), charCap);
   return s.replace(/\\/g, "\\\\").replace(/\|/g, "\\|").replace(/\n/g, " ").replace(/\r/g, "");
 }
 
@@ -20,6 +30,7 @@ export function renderMarkdownTable(
   sql: string,
   connection: Connection,
   rowCap: number,
+  cellCharCap: number = DEFAULTS.cellCharCap,
 ): string {
   const hash = simpleHash(`${connection}\n${sql.trim()}`);
   const ts = new Date().toISOString();
@@ -34,9 +45,11 @@ export function renderMarkdownTable(
     return `${open}\n\n_(0 rows)_\n\n${close}`;
   }
 
-  const header = "| " + columns.map(escapeCell).join(" | ") + " |";
+  const header = "| " + columns.map((c) => escapeCell(c, cellCharCap)).join(" | ") + " |";
   const sep = "| " + columns.map(() => "---").join(" | ") + " |";
-  const body = shown.map((r) => "| " + columns.map((c) => escapeCell(r[c])).join(" | ") + " |");
+  const body = shown.map(
+    (r) => "| " + columns.map((c) => escapeCell(r[c], cellCharCap)).join(" | ") + " |",
+  );
   const emptyNotice = totalRows === 0 ? "\n\n> 0 rows" : "";
   const truncated =
     totalRows > cap ? `\n\n> … ${totalRows - cap} more rows hidden (cap ${cap})` : "";
@@ -49,6 +62,7 @@ export function renderDomTable(
   rows: Row[],
   columns: string[],
   rowCap: number,
+  cellCharCap: number = DEFAULTS.cellCharCap,
 ) {
   if (columns.length === 0) {
     parent.createEl("em", { text: "(0 rows)" });
@@ -69,8 +83,12 @@ export function renderDomTable(
     const tr = tbody.createEl("tr");
     for (const c of columns) {
       const td = tr.createEl("td");
-      const v = row[c];
-      td.setText(v === null || v === undefined ? "" : typeof v === "object" ? JSON.stringify(v) : String(v));
+      const full = stringifyCell(row[c]);
+      const display = truncateString(full, cellCharCap);
+      td.setText(display);
+      if (display !== full) {
+        td.title = full;
+      }
     }
   }
 
@@ -92,4 +110,10 @@ export function normalizedRowCap(rowCap: number): number {
   return Number.isFinite(rowCap) && rowCap > 0
     ? Math.min(Math.floor(rowCap), 10000)
     : DEFAULTS.rowCap;
+}
+
+export function normalizedCellCharCap(charCap: number): number {
+  return Number.isFinite(charCap) && charCap > 0
+    ? Math.min(Math.floor(charCap), 10000)
+    : DEFAULTS.cellCharCap;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,12 +27,14 @@ export interface Settings {
   rowCap: number;
   cellCharCap: number;
   scheduleEnabled: boolean;
+  resetAfterSchedule: boolean;
   refreshLog: RefreshLogEntry[];
 }
 
 export interface QueryRunResult {
   rows: Row[];
   columns: string[];
+  truncated: boolean;
 }
 
 export interface SweepResult {
@@ -47,5 +49,8 @@ export const DEFAULTS: Settings = {
   rowCap: 100,
   cellCharCap: 80,
   scheduleEnabled: false,
+  resetAfterSchedule: true,
   refreshLog: [],
 };
+
+export const AUTO_DISABLE_FAILURE_THRESHOLD = 3;

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export interface Settings {
   mdToken: string;
   dbPath: string;
   rowCap: number;
+  cellCharCap: number;
   scheduleEnabled: boolean;
   refreshLog: RefreshLogEntry[];
 }
@@ -44,6 +45,7 @@ export const DEFAULTS: Settings = {
   mdToken: "",
   dbPath: ":memory:",
   rowCap: 100,
+  cellCharCap: 80,
   scheduleEnabled: false,
   refreshLog: [],
 };

--- a/styles.css
+++ b/styles.css
@@ -29,6 +29,13 @@
   height: 14px;
 }
 
+.motherduck-block__stale-warn {
+  color: var(--text-warning);
+  font-size: var(--font-ui-smaller);
+  padding: 0 4px;
+  cursor: help;
+}
+
 .motherduck-refresh-control {
   display: flex;
   align-items: center;

--- a/styles.css
+++ b/styles.css
@@ -100,6 +100,17 @@
   vertical-align: top;
 }
 
+.motherduck-result-table td {
+  max-width: 32ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.markdown-source-view.is-live-preview .motherduck-cache-block {
+  display: none;
+}
+
 @media (max-width: 520px) {
   .motherduck-block__badge {
     align-items: flex-start;

--- a/test/markdown.test.ts
+++ b/test/markdown.test.ts
@@ -1,6 +1,11 @@
 import { strict as assert } from "node:assert";
 import { test } from "node:test";
-import { findBlocks, findCacheHashAfterLine, writeSentinelAfterBlock } from "../src/markdown";
+import {
+  findBlocks,
+  findCacheHashAfterLine,
+  removeSentinelAfterBlock,
+  writeSentinelAfterBlock,
+} from "../src/markdown";
 
 test("findBlocks parses duckdb and motherduck fences with info text", () => {
   const blocks = findBlocks(
@@ -116,6 +121,73 @@ test("findCacheHashAfterLine returns null when there is no cache", () => {
   ].join("\n");
 
   assert.equal(findCacheHashAfterLine(content, 2), null);
+});
+
+test("removeSentinelAfterBlock strips a cache directly below the block", () => {
+  const content = [
+    "before",
+    "```duckdb",
+    "select 1",
+    "```",
+    "",
+    "<!-- md:cache hash=abc -->",
+    "",
+    "| x |",
+    "| - |",
+    "| 1 |",
+    "",
+    "<!-- md:cache-end -->",
+    "",
+    "after",
+  ].join("\n");
+  const block = findBlocks(content)[0];
+
+  assert.equal(
+    removeSentinelAfterBlock(content, block),
+    ["before", "```duckdb", "select 1", "```", "", "after"].join("\n"),
+  );
+});
+
+test("removeSentinelAfterBlock returns content unchanged when no cache present", () => {
+  const content = ["```duckdb", "select 1", "```", "", "after"].join("\n");
+  const block = findBlocks(content)[0];
+
+  assert.equal(removeSentinelAfterBlock(content, block), content);
+});
+
+test("removeSentinelAfterBlock handles a cache at end of file", () => {
+  const content = [
+    "```duckdb",
+    "select 1",
+    "```",
+    "",
+    "<!-- md:cache hash=abc -->",
+    "",
+    "result",
+    "",
+    "<!-- md:cache-end -->",
+  ].join("\n");
+  const block = findBlocks(content)[0];
+
+  assert.equal(
+    removeSentinelAfterBlock(content, block),
+    ["```duckdb", "select 1", "```", ""].join("\n"),
+  );
+});
+
+test("removeSentinelAfterBlock leaves caches that aren't directly after the block", () => {
+  const content = [
+    "```duckdb",
+    "select 1",
+    "```",
+    "",
+    "intervening paragraph",
+    "<!-- md:cache hash=abc -->",
+    "<!-- md:cache-end -->",
+  ].join("\n");
+  const block = findBlocks(content)[0];
+
+  assert.equal(removeSentinelAfterBlock(content, block), content);
 });
 
 test("findCacheHashAfterLine ignores caches separated by other content", () => {

--- a/test/markdown.test.ts
+++ b/test/markdown.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from "node:assert";
 import { test } from "node:test";
-import { findBlocks, writeSentinelAfterBlock } from "../src/markdown";
+import { findBlocks, findCacheHashAfterLine, writeSentinelAfterBlock } from "../src/markdown";
 
 test("findBlocks parses duckdb and motherduck fences with info text", () => {
   const blocks = findBlocks(
@@ -86,4 +86,48 @@ test("writeSentinelAfterBlock replaces an existing frozen result", () => {
   assert.match(updated, /hash=new/);
   assert.doesNotMatch(updated, /hash=old|old/);
   assert.match(updated, /\nafter$/);
+});
+
+test("findCacheHashAfterLine returns the hash from the next sentinel", () => {
+  const content = [
+    "```duckdb",          // 0
+    "select 1",           // 1
+    "```",                // 2 ← lineEnd
+    "",                   // 3
+    "<!-- md:cache hash=abc12345 conn=local ts=2026-05-06T00:00:00Z rows=1 -->", // 4
+    "",                   // 5
+    "| x |",              // 6
+    "| - |",              // 7
+    "| 1 |",              // 8
+    "",                   // 9
+    "<!-- md:cache-end -->", // 10
+  ].join("\n");
+
+  assert.equal(findCacheHashAfterLine(content, 2), "abc12345");
+});
+
+test("findCacheHashAfterLine returns null when there is no cache", () => {
+  const content = [
+    "```duckdb",
+    "select 1",
+    "```",
+    "",
+    "regular paragraph",
+  ].join("\n");
+
+  assert.equal(findCacheHashAfterLine(content, 2), null);
+});
+
+test("findCacheHashAfterLine ignores caches separated by other content", () => {
+  const content = [
+    "```duckdb",
+    "select 1",
+    "```",
+    "",
+    "intervening text",
+    "<!-- md:cache hash=deadbeef conn=local ts=t rows=0 -->",
+    "<!-- md:cache-end -->",
+  ].join("\n");
+
+  assert.equal(findCacheHashAfterLine(content, 2), null);
 });

--- a/test/schedule-path.test.ts
+++ b/test/schedule-path.test.ts
@@ -1,7 +1,19 @@
 import { strict as assert } from "node:assert";
 import { test } from "node:test";
 import { shortPathLabel } from "../src/path";
-import { isOverdue } from "../src/schedule";
+import { consecutiveAllErrorFailures, isAllErrorFailure, isOverdue } from "../src/schedule";
+import type { RefreshLogEntry } from "../src/types";
+
+function entry(partial: Partial<RefreshLogEntry>): RefreshLogEntry {
+  return {
+    ts: "2026-05-06T00:00:00Z",
+    path: "note.md",
+    trigger: "schedule",
+    blocks: 0,
+    errored: 0,
+    ...partial,
+  };
+}
 
 test("isOverdue treats missing and invalid timestamps as due", () => {
   assert.equal(isOverdue("daily", null, Date.UTC(2026, 4, 4)), true);
@@ -14,6 +26,43 @@ test("isOverdue compares cadence against a provided clock", () => {
   assert.equal(isOverdue("daily", new Date(now - 24 * 60 * 60 * 1000).toISOString(), now), true);
   assert.equal(isOverdue("daily", new Date(now - 23 * 60 * 60 * 1000).toISOString(), now), false);
   assert.equal(isOverdue("weekly", new Date(now - 7 * 24 * 60 * 60 * 1000).toISOString(), now), true);
+});
+
+test("isAllErrorFailure flags entries where every block failed or the file errored at the boundary", () => {
+  // Caught at outer try/catch — file couldn't be processed at all
+  assert.equal(isAllErrorFailure(entry({ blocks: 0, errored: 0, errorMessage: "vault read failed" })), true);
+  // processAllBlocks: every block in the note errored
+  assert.equal(isAllErrorFailure(entry({ blocks: 0, errored: 2, errorMessage: "boom" })), true);
+  // Partial failure — one block worked, one errored — NOT counted
+  assert.equal(isAllErrorFailure(entry({ blocks: 1, errored: 1, errorMessage: "boom" })), false);
+  // Clean success
+  assert.equal(isAllErrorFailure(entry({ blocks: 3, errored: 0 })), false);
+});
+
+test("consecutiveAllErrorFailures counts a streak from the head, ignoring other paths", () => {
+  // newest-first ordering, like settings.refreshLog
+  const log = [
+    entry({ path: "note.md", blocks: 0, errored: 1, errorMessage: "x" }),
+    entry({ path: "other.md", blocks: 1, errored: 0 }), // ignored
+    entry({ path: "note.md", blocks: 0, errored: 1, errorMessage: "x" }),
+    entry({ path: "note.md", blocks: 0, errored: 0, errorMessage: "x" }),
+    entry({ path: "note.md", blocks: 1, errored: 0 }), // success: streak ends here
+    entry({ path: "note.md", blocks: 0, errored: 1, errorMessage: "x" }),
+  ];
+
+  assert.equal(consecutiveAllErrorFailures(log, "note.md"), 3);
+  assert.equal(consecutiveAllErrorFailures(log, "other.md"), 0);
+  assert.equal(consecutiveAllErrorFailures(log, "missing.md"), 0);
+});
+
+test("consecutiveAllErrorFailures: partial failure breaks the streak", () => {
+  const log = [
+    entry({ path: "note.md", blocks: 0, errored: 1, errorMessage: "x" }),
+    entry({ path: "note.md", blocks: 1, errored: 1, errorMessage: "x" }), // partial: streak ends
+    entry({ path: "note.md", blocks: 0, errored: 1, errorMessage: "x" }),
+  ];
+
+  assert.equal(consecutiveAllErrorFailures(log, "note.md"), 1);
 });
 
 test("shortPathLabel keeps badges compact", () => {

--- a/test/table.test.ts
+++ b/test/table.test.ts
@@ -81,6 +81,21 @@ test("renderMarkdownTable truncates rendered rows at the row cap", () => {
   assert.match(rendered, /1 more rows hidden \(cap 2\)/);
 });
 
+test("renderMarkdownTable marks truncated streamed results in sentinel + body", () => {
+  const rendered = renderMarkdownTable(
+    [{ x: 1 }, { x: 2 }],
+    ["x"],
+    "select x from t",
+    "local",
+    100,
+    80,
+    true, // truncated
+  );
+
+  assert.match(rendered, /rows=2\+/);
+  assert.match(rendered, /more rows hidden \(cap 100; query stopped early\)/);
+});
+
 test("renderMarkdownTable truncates long cell values per cellCharCap", () => {
   const long = "x".repeat(200);
   const rendered = renderMarkdownTable(

--- a/test/table.test.ts
+++ b/test/table.test.ts
@@ -1,6 +1,13 @@
 import { strict as assert } from "node:assert";
 import { test } from "node:test";
-import { escapeCell, normalizedRowCap, renderMarkdownTable, simpleHash } from "../src/table";
+import {
+  escapeCell,
+  normalizedCellCharCap,
+  normalizedRowCap,
+  renderMarkdownTable,
+  simpleHash,
+  truncateString,
+} from "../src/table";
 
 test("escapeCell produces markdown-safe table cells", () => {
   assert.equal(escapeCell("a|b\nc\\d\r"), "a\\|b c\\\\d");
@@ -13,6 +20,27 @@ test("normalizedRowCap falls back and clamps large values", () => {
   assert.equal(normalizedRowCap(Number.NaN), 100);
   assert.equal(normalizedRowCap(2.8), 2);
   assert.equal(normalizedRowCap(20000), 10000);
+});
+
+test("normalizedCellCharCap falls back and clamps large values", () => {
+  assert.equal(normalizedCellCharCap(0), 80);
+  assert.equal(normalizedCellCharCap(Number.NaN), 80);
+  assert.equal(normalizedCellCharCap(15.7), 15);
+  assert.equal(normalizedCellCharCap(50000), 10000);
+});
+
+test("truncateString slices to cap-1 chars and appends an ellipsis", () => {
+  assert.equal(truncateString("hello", 10), "hello");
+  assert.equal(truncateString("abcdefghij", 10), "abcdefghij");
+  assert.equal(truncateString("abcdefghijk", 10), "abcdefghi…");
+  assert.equal(truncateString("a really long sentence", 10), "a really …");
+});
+
+test("escapeCell truncates long values before escaping", () => {
+  const long = "a".repeat(200);
+  const out = escapeCell(long, 20);
+  assert.equal(out.length, 20);
+  assert.ok(out.endsWith("…"));
 });
 
 test("renderMarkdownTable includes connection-aware hash and escaped headers", () => {
@@ -51,4 +79,20 @@ test("renderMarkdownTable truncates rendered rows at the row cap", () => {
   assert.match(rendered, /\| 2 \|/);
   assert.doesNotMatch(rendered, /\| 3 \|/);
   assert.match(rendered, /1 more rows hidden \(cap 2\)/);
+});
+
+test("renderMarkdownTable truncates long cell values per cellCharCap", () => {
+  const long = "x".repeat(200);
+  const rendered = renderMarkdownTable(
+    [{ note: long }],
+    ["note"],
+    "select note from t",
+    "local",
+    100,
+    25,
+  );
+
+  const cellLine = rendered.split("\n").find((l) => l.startsWith("| x")) ?? "";
+  assert.ok(cellLine.includes("…"), "expected ellipsis in truncated cell line");
+  assert.ok(!cellLine.includes("x".repeat(100)), "expected no full long value");
 });


### PR DESCRIPTION
## Summary

Started as Simon (ssp.sh)'s feedback punch list, grew to include UX fixes and memory optimizations that came out of dogfooding the result. Plan: `/Users/mehdio/.claude/plans/eager-stirring-aurora.md`.

### Original feedback batch (commit `44bf5b3`)
- **Cell truncation** — long cell values truncate with `…` in both the live DOM table and the frozen markdown. New `cellCharCap` setting (default 80). Hovering a truncated cell in the live result shows the full value via `title=`.
- **Refresh query at cursor** — new command (`refresh-at-cursor`) that re-runs and re-freezes only the block under the cursor. Bind a hotkey for vim-mode iteration. `freeze-at-cursor` stays as an alias.
- **Hide frozen output in Live Preview** — `registerMarkdownPostProcessor` tags any element inside `<!-- md:cache ... --> ... <!-- md:cache-end -->` with class `motherduck-cache-block`; CSS hides it under `.markdown-source-view.is-live-preview`. Reading mode unchanged.
- **README** — lead with "Bring external data into your Obsidian notes," add *Why this and not Dataview?*, *When to use it*, two extra SQL examples (CSV read, MotherDuck × local CSV join), plain-markdown call-out, swap CLI link to the official `https://obsidian.md/help/cli` (same `obsidian eval code="..."` syntax), document new commands + cell cap setting.

### Stale-cache & Clear UX (commits `3d77e4f`, `a11117f`, `73ace9e`)
- **Stale-cache banner** — at render time, parse `hash=...` from the cache sentinel below the block and compare against `simpleHash(connection + sql)`. On mismatch, show a `⚠ cache stale` pill in the badge row. Surfaces query/cache divergence (SQL was edited, fence type changed, scheduled refresh failing silently). Doesn't touch the cached data.
- **Clear freeze button + command** — per-block "Clear freeze" button next to Run/Freeze (rendered only when a cache is present below) and a `Clear freeze at cursor` command. Strips the sentinel range without touching the SQL block. The natural one-click answer when a block warns "⚠ cache stale".

### Schedule maintenance (commit `c9b75ad`)
- **Unschedule all** button in settings → strips `duckdb-motherduck-refresh*` frontmatter from every note in the vault. For bulk-disabling auto-refresh after experimentation.

### Memory optimizations (commit `01855ad`)
Triggered by a real-world report of Obsidian Helper sitting at 2.8 GB after running the WHO ambient air quality CSV query (~40k rows). With these three changes, the Helper baseline returned to normal.

- **Streaming runtime with early stop.** `runQuery(sql, rowCap?)` now uses `conn.send()` (DuckDB-WASM) and `safeEvaluateStreamingQuery` (MotherDuck) when rowCap is set, reading batches until rowCap+1 rows are buffered, then cancelling the stream. Pipeline-friendly queries like `FROM 'huge.csv'` no longer scan the whole file or materialize 40k rows in JS just to slice 100. Result carries `truncated: boolean`; sentinel rendered with `rows=N+` and a `more rows hidden (cap N; query stopped early)` notice. Public API `app.plugins.getPlugin(...).api.runQuery(sql)` is unchanged — undefined `rowCap` falls back to full materialization.
- **Auto-reset workers after each scheduled sweep.** New setting `resetAfterSchedule` (default on). Once the hourly sweep finishes, `runtimeManager.reset()` terminates both WASM workers. Memory drops to baseline; the next interactive query pays a ~1–2s init cost. Toggle in Settings → Scheduled refresh.
- **Auto-unschedule perpetually-failing notes.** After three consecutive all-error sweep entries for the same path (every block in the note errored, or the file couldn't be processed at all), the plugin strips `duckdb-motherduck-refresh*` and writes an auto-unschedule entry to the activity log. Partial failures (some blocks succeed, some error) do NOT count — a working block keeps the schedule alive. New helpers `isAllErrorFailure` and `consecutiveAllErrorFailures` in `src/schedule.ts` with unit tests.

Vault-as-data was discussed and parked.

## Test plan

- [x] `npm test` — 31/31 pass; new tests cover `truncateString`, `normalizedCellCharCap`, `escapeCell` truncation, `renderMarkdownTable` per-cell + truncated-stream rendering, `findCacheHashAfterLine`, `removeSentinelAfterBlock`, `isAllErrorFailure`, `consecutiveAllErrorFailures`
- [x] `npm run build` — clean, `main.js` produced
- [x] `npx tsc --noEmit` — clean
- [x] **Manual smoke test in a real vault**: confirmed Live Preview hides the frozen table, Reading mode shows it, long cells get ellipsis + tooltip, `Refresh query at cursor` updates only the block under the cursor, `⚠ cache stale` banner appears on hash mismatch, `Clear freeze` wipes the sentinel range, `Unschedule all` strips the frontmatter from every opted-in note
- [x] **Memory regression test**: ran the 40k-row WHO CSV query; Obsidian Helper baseline returned to normal (~850 MB) instead of climbing to 2.8 GB

🤖 Generated with [Claude Code](https://claude.com/claude-code)