### PR TITLE
Address dumky's feedback: BRAT install, SQL UX polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,19 @@ Local DuckDB has three sub-modes, set via the **Path to local DuckDB file** sett
 - A bare filename like `notes.duckdb` for a persistent database in browser-managed storage (Origin Private File System). Survives Obsidian restart, full read/write, lives outside your vault.
 - An absolute path like `/Users/you/data.duckdb` or `C:\Users\you\data.duckdb` to query an existing `.duckdb` file from disk. **Read-only**: writes succeed inside the worker but don't persist back to the file.
 
-## Install (manual, for now)
+## Install
 
-The plugin isn't in the Obsidian community store yet. To install:
+The plugin isn't in the Obsidian community store yet — the review queue is deep, so until it lands the easiest path is BRAT.
+
+### Recommended: via BRAT
+
+1. Install [BRAT](https://github.com/TfTHacker/obsidian42-brat) from Settings → Community plugins.
+2. Open BRAT's settings → **Add beta plugin** → paste the repository: `motherduckdb/obsidian-duckdb-motherduck`.
+3. BRAT will pull the latest tagged release and install it. Enable *DuckDB & MotherDuck* in Settings → Community plugins.
+
+BRAT also keeps the plugin updated when new releases ship.
+
+### Manual
 
 1. Clone this repo.
 2. `npm install && npm run build`, produces `main.js`.

--- a/main.ts
+++ b/main.ts
@@ -32,6 +32,7 @@ export default class MotherDuckPlugin extends Plugin {
   private sweepTimeout: number | null = null;
   private sweepInterval: number | null = null;
   private sweepRunning = false;
+  private collapsedBlocks = new Map<string, boolean>();
   api!: {
     refreshFile: (path: string) => Promise<string>;
     runQuery: (sql: string, connection?: Connection) => Promise<QueryRunResult>;
@@ -157,6 +158,15 @@ export default class MotherDuckPlugin extends Plugin {
 
   async resetRuntimes(only?: Connection) {
     await this.runtimeManager.reset(only);
+  }
+
+  isBlockCollapsed(key: string): boolean {
+    return this.collapsedBlocks.get(key) === true;
+  }
+
+  setBlockCollapsed(key: string, collapsed: boolean): void {
+    if (collapsed) this.collapsedBlocks.set(key, true);
+    else this.collapsedBlocks.delete(key);
   }
 
   async runQuery(

--- a/src/query-block.ts
+++ b/src/query-block.ts
@@ -1,4 +1,13 @@
-import { App, MarkdownPostProcessorContext, Notice, TFile, setIcon } from "obsidian";
+import {
+  App,
+  MarkdownPostProcessorContext,
+  MarkdownRenderChild,
+  MarkdownRenderer,
+  MarkdownView,
+  Notice,
+  TFile,
+  setIcon,
+} from "obsidian";
 import { DUCKDB_ICON, MOTHERDUCK_ICON } from "./icons";
 import { findCacheHashAfterLine } from "./markdown";
 import { shortPathLabel } from "./path";
@@ -16,6 +25,8 @@ export interface QueryBlockHost {
     connection: Connection,
   ): Promise<void>;
   clearRenderedBlock(ctx: MarkdownPostProcessorContext, el: HTMLElement): Promise<void>;
+  isBlockCollapsed(key: string): boolean;
+  setBlockCollapsed(key: string, collapsed: boolean): void;
 }
 
 export function renderQueryBlock(
@@ -33,6 +44,10 @@ export function renderQueryBlock(
 
   const wrap = el.createDiv({ cls: "motherduck-block" });
   const badge = wrap.createDiv({ cls: "motherduck-block__badge" });
+
+  const collapseBtn = badge.createEl("button", { cls: "motherduck-block__collapse" });
+  collapseBtn.setAttr("type", "button");
+
   const iconWrap = badge.createDiv({ cls: "motherduck-block__engine-icon" });
   iconWrap.innerHTML = connection === "cloud" ? MOTHERDUCK_ICON : DUCKDB_ICON;
 
@@ -54,8 +69,42 @@ export function renderQueryBlock(
 
   attachRefreshDropdown(host, badge, ctx);
 
-  const pre = wrap.createEl("pre", { cls: "motherduck-block__sql" });
-  pre.createEl("code", { text: sql });
+  const sqlHost = wrap.createDiv({ cls: "motherduck-block__sql motherduck-block__sql--editable" });
+  sqlHost.title = "Click to edit";
+  const sqlChild = new MarkdownRenderChild(sqlHost);
+  ctx.addChild(sqlChild);
+  void MarkdownRenderer.render(
+    host.app,
+    "```sql\n" + sql + "\n```",
+    sqlHost,
+    ctx.sourcePath,
+    sqlChild,
+  );
+
+  sqlHost.addEventListener("click", (evt) => {
+    const sel = window.getSelection();
+    if (sel && sel.toString().length > 0) return;
+
+    const sectionInfo = ctx.getSectionInfo(el);
+    if (!sectionInfo) return;
+    const view = host.app.workspace.getActiveViewOfType(MarkdownView);
+    if (!view) return;
+
+    const goToLine = sectionInfo.lineStart + 1;
+    const place = () => {
+      view.editor.focus();
+      view.editor.setCursor({ line: goToLine, ch: 0 });
+    };
+    if (view.getMode() !== "source") {
+      const state = view.getState();
+      void view
+        .setState({ ...state, mode: "source" }, { history: false })
+        .then(place);
+    } else {
+      place();
+    }
+    evt.preventDefault();
+  });
 
   const btnRow = wrap.createDiv({ cls: "motherduck-block__controls" });
 
@@ -82,6 +131,21 @@ export function renderQueryBlock(
 
   const status = btnRow.createEl("span", { cls: "motherduck-block__status" });
   const resultEl = wrap.createDiv({ cls: "motherduck-block__result" });
+
+  const collapseKey = `${ctx.sourcePath}::${simpleHash(`${connection}\n${sql}`)}`;
+  const applyCollapsed = (collapsed: boolean) => {
+    wrap.toggleClass("motherduck-block--collapsed", collapsed);
+    setIcon(collapseBtn, collapsed ? "chevron-right" : "chevron-down");
+    collapseBtn.setAttr("aria-label", collapsed ? "Expand SQL block" : "Collapse SQL block");
+    collapseBtn.title = collapsed ? "Expand" : "Collapse";
+  };
+  applyCollapsed(host.isBlockCollapsed(collapseKey));
+  collapseBtn.addEventListener("click", (evt) => {
+    evt.stopPropagation();
+    const next = !wrap.hasClass("motherduck-block--collapsed");
+    host.setBlockCollapsed(collapseKey, next);
+    applyCollapsed(next);
+  });
 
   runBtn.addEventListener("click", async () => {
     resultEl.empty();

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -63,6 +63,7 @@ export class SettingsTab extends PluginSettingTab {
           }),
       );
 
+    let duckdbStatusEl: HTMLSpanElement;
     new Setting(this.containerEl)
       .setName("Test DuckDB connection")
       .setDesc("Runs a tiny local query using the current DuckDB setting.")
@@ -70,18 +71,24 @@ export class SettingsTab extends PluginSettingTab {
         b.setButtonText("Test").onClick(async () => {
           b.setDisabled(true);
           b.setButtonText("Testing...");
+          resetTestStatus(duckdbStatusEl);
           try {
             const result = await this.plugin.runQuery("SELECT 42 AS ok", "local");
             new Notice(`DuckDB ok (${result.rows.length} row)`);
+            showTestStatus(duckdbStatusEl, "ok");
           } catch (e) {
             const msg = e instanceof Error ? e.message : String(e);
             new Notice(`DuckDB error: ${msg}`);
+            showTestStatus(duckdbStatusEl, "err");
           } finally {
             b.setDisabled(false);
             b.setButtonText("Test");
           }
         }),
-      );
+      )
+      .then((s) => {
+        duckdbStatusEl = s.controlEl.createSpan({ cls: "motherduck-test-status" });
+      });
 
     renderSectionHeader(this.containerEl, MOTHERDUCK_ICON, "MotherDuck", {
       text: "Used by ```motherduck code blocks. ",
@@ -129,6 +136,7 @@ export class SettingsTab extends PluginSettingTab {
           });
       });
 
+    let mdStatusEl: HTMLSpanElement;
     new Setting(this.containerEl)
       .setName("Test MotherDuck connection")
       .setDesc("Runs a tiny cloud query using the current token.")
@@ -136,18 +144,24 @@ export class SettingsTab extends PluginSettingTab {
         b.setButtonText("Test").onClick(async () => {
           b.setDisabled(true);
           b.setButtonText("Testing...");
+          resetTestStatus(mdStatusEl);
           try {
             const result = await this.plugin.runQuery("SELECT 42 AS ok", "cloud");
             new Notice(`MotherDuck ok (${result.rows.length} row)`);
+            showTestStatus(mdStatusEl, "ok");
           } catch (e) {
             const msg = e instanceof Error ? e.message : String(e);
             new Notice(`MotherDuck error: ${msg}`);
+            showTestStatus(mdStatusEl, "err");
           } finally {
             b.setDisabled(false);
             b.setButtonText("Test");
           }
         }),
-      );
+      )
+      .then((s) => {
+        mdStatusEl = s.controlEl.createSpan({ cls: "motherduck-test-status" });
+      });
 
     this.containerEl.createEl("h3", { text: "Scheduled refresh" });
 
@@ -335,6 +349,21 @@ export class SettingsTab extends PluginSettingTab {
         this.display();
       }),
     );
+  }
+}
+
+function resetTestStatus(el: HTMLSpanElement | undefined) {
+  if (!el) return;
+  el.empty();
+  el.removeClass("motherduck-test-status--ok", "motherduck-test-status--err");
+}
+
+function showTestStatus(el: HTMLSpanElement | undefined, kind: "ok" | "err") {
+  if (!el) return;
+  el.setText(kind === "ok" ? "✓" : "✗");
+  el.addClass(kind === "ok" ? "motherduck-test-status--ok" : "motherduck-test-status--err");
+  if (kind === "ok") {
+    window.setTimeout(() => resetTestStatus(el), 4000);
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -54,9 +54,23 @@
 }
 
 .motherduck-block__sql {
-  margin: 0 0 8px;
+  margin: 0 0 14px;
   overflow-x: auto;
   font-size: var(--font-ui-smaller);
+}
+
+.motherduck-block__sql > pre {
+  margin: 0;
+  overflow-x: auto;
+}
+
+.motherduck-block__sql--editable {
+  cursor: text;
+  border-radius: 4px;
+}
+
+.motherduck-block__sql--editable:hover {
+  background: var(--background-modifier-hover);
 }
 
 .motherduck-block__controls {
@@ -64,6 +78,51 @@
   align-items: center;
   gap: 8px;
   flex-wrap: wrap;
+  margin-top: 4px;
+}
+
+.motherduck-block__collapse {
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  padding: 2px;
+  margin-right: 2px;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  color: var(--text-muted);
+}
+
+.motherduck-block__collapse:hover {
+  color: var(--text-normal);
+}
+
+.motherduck-block__collapse svg {
+  width: 14px;
+  height: 14px;
+}
+
+.motherduck-block--collapsed .motherduck-block__sql,
+.motherduck-block--collapsed .motherduck-block__controls,
+.motherduck-block--collapsed .motherduck-block__result {
+  display: none;
+}
+
+.motherduck-block--collapsed .motherduck-block__badge {
+  margin-bottom: 0;
+}
+
+.motherduck-test-status {
+  margin-left: 8px;
+  font-weight: 600;
+}
+
+.motherduck-test-status--ok {
+  color: var(--text-success);
+}
+
+.motherduck-test-status--err {
+  color: var(--text-error);
 }
 
 .motherduck-block__button {


### PR DESCRIPTION
## Summary

Round of UX polish based on feedback from dumky after trying the 0.1.0 release.

- **README**: now that the plugin has a release, recommend [BRAT](https://github.com/TfTHacker/obsidian42-brat) as the default install method (`motherduckdb/obsidian-duckdb-motherduck` as the beta plugin input). Manual install is kept as a fallback under `### Manual`. The community-store path is still backed up by a deep review queue.
- **Test Token buttons**: clicking *Test* on either DuckDB or MotherDuck now shows an inline `✓` (auto-fades after 4s) or `✗` next to the button, on top of the existing toast. Previously the only success signal was a brief "OK" toast that was easy to miss.
- **SQL syntax highlighting**: the rendered SQL is now passed through Obsidian's built-in Prism via `MarkdownRenderer.render`, so it picks up the user's theme colors instead of being plain monospaced text.
- **Click-to-edit**: clicking anywhere on the SQL frame moves the cursor to that block in source mode (switching from reading mode if needed), matching how a normal Obsidian code block behaves. Mid text-selection clicks are ignored so the user can still copy SQL out of the rendered block.
- **Fold/collapse**: a chevron toggle in the badge row collapses the entire block (SQL + buttons + results), leaving only the badge — same mental model as folding a markdown header. State is held in-memory on the plugin host, keyed by `path::hash(connection+sql)`, so it survives re-renders within a session and resets on Obsidian restart.
- **Spacing**: bumped the gap between the SQL frame and the buttons row (8px → 14px + 4px top margin on controls) so the buttons no longer feel glued to the code.

## Files

- `README.md` — install section rewrite.
- `src/settings-tab.ts` — inline status span + helpers (`resetTestStatus` / `showTestStatus`).
- `src/query-block.ts` — `MarkdownRenderer` for SQL, click-to-edit handler on `sqlHost`, collapse toggle wired to host methods.
- `main.ts` — `collapsedBlocks` map + `isBlockCollapsed` / `setBlockCollapsed`.
- `styles.css` — new rules for `.motherduck-block__sql--editable`, `.motherduck-block__collapse`, `.motherduck-block--collapsed`, `.motherduck-test-status*`, plus the spacing tweak.

## Test plan

- [ ] `npm run build` succeeds, `npm test` passes (31/31).
- [ ] In a note with a ` ```duckdb ` block: SQL renders with theme colors; clicking the frame in Live Preview drops the cursor on the SQL line; clicking in Reading mode switches to source first.
- [ ] Selecting text inside the SQL frame with a mouse drag does *not* steal focus mid-drag.
- [ ] Click the chevron in the badge row → SQL, buttons, and result hide; click again → expand. Edit + re-render keeps the fold state within the session.
- [ ] Settings → *Test DuckDB* with default `:memory:` → toast + inline green `✓` next to the button; `✓` fades after ~4s. Bad MotherDuck token → toast + inline red `✗`.
- [ ] Visual: noticeably more whitespace between the SQL frame and the Run/Freeze buttons.
- [ ] No regressions on Run / Freeze / Clear freeze, the refresh dropdown, or `⚠ cache stale` warn pill.