### PR TITLE
Disclose network access + strip dead script-loader from worker bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,17 +182,20 @@ npm run dev       # watch mode, rebuilds on save
 
 `main.js` ends up around 2 MB because the local DuckDB WASM worker script is bundled inline. The `.wasm` binary itself is fetched from jsDelivr at runtime (see *Remote assets*).
 
-## Remote assets
+## Network access
 
-When a `duckdb` block runs, the plugin fetches the DuckDB WASM binary (~7 MB gzipped) from jsDelivr the first time:
+The plugin makes network calls only in response to actions you take. There is **no telemetry**, **no analytics**, **no calls to motherduck.com or any third-party for any reason other than fulfilling a SQL query or fetching a WASM runtime you triggered**.
 
-```
-https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@<version>/dist/duckdb-eh.wasm
-```
+Concretely:
 
-When a `motherduck` block runs, the MotherDuck WASM extension and its DuckDB worker bundle are fetched from `https://app.motherduck.com/duckdb-wasm-assets/<version>/` during connection setup.
+| When | What | Where | Sends |
+| --- | --- | --- | --- |
+| First time a `duckdb` block runs | DuckDB WASM binary (~7 MB gzipped), once, then browser-cached | `https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@<version>/dist/duckdb-eh.wasm` | nothing — public CDN GET |
+| First time a `motherduck` block runs | MotherDuck WASM extension + DuckDB worker bundle | `https://app.motherduck.com/duckdb-wasm-assets/<version>/` | nothing — public assets GET |
+| Every `motherduck` block run (including scheduled refresh) | Your SQL query and your token | Your MotherDuck workspace | your SQL + your token |
+| Scheduled refresh sweep (when enabled) | An hourly sweep checks frontmatter-opted-in notes and re-runs their blocks. Only `motherduck` blocks make network calls; `duckdb` blocks stay local. The sweep itself does no network I/O — it walks the vault and triggers blocks. | Same as the row above (only `motherduck` blocks touch the network) | Same as above |
 
-Both are cached by the browser. No other network activity is added by the plugin.
+Scheduled refresh is **off by default** and opted into per-note via the `Refresh: daily/weekly` dropdown above any SQL block, which writes `duckdb-motherduck-refresh: daily|weekly` to that note's frontmatter. Toggle it off globally in Settings → *Auto-refresh scheduled notes*.
 
 ## Requirements
 

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -8,15 +8,40 @@ const prod = process.argv[2] === "production";
 // DuckDB WASM ships its worker as a regular .js file. Import it as a text
 // string so we can wrap it in a same-origin Blob URL at runtime (the Electron
 // custom-scheme renderer can't load cross-origin worker scripts directly).
+//
+// While we're at it, strip the body of `_emscripten_async_load_script`. The
+// helper is Emscripten runtime boilerplate (gets emitted into every -sASYNCIFY
+// build); it calls `document.createElement("script")` and `eval(data)`. In our
+// usage it is dead code in two ways:
+//   1. Workers have no `document` global, so reaching the createElement call
+//      would throw immediately.
+//   2. DuckDB-wasm's own code paths never invoke the helper; it is only
+//      exposed via the wasm imports table for the generic Emscripten case.
+// Replacing the body with a throw stub keeps the symbol bound (the imports
+// table reference stays valid) while removing the patterns the Obsidian
+// Community scanner heuristically flags as "dynamic script creation" and
+// "eval of network response".
+const STRIP_EMSCRIPTEN_SCRIPT_LOADER =
+  /var _emscripten_async_load_script=function\(url,onload,onerror\)\{[\s\S]*?\};(?=_emscripten_async_load_script\.sig)/g;
+const ASYNC_LOAD_SCRIPT_STUB =
+  'var _emscripten_async_load_script=function(){throw new Error("emscripten_async_load_script unreachable in worker context")};';
+
 const duckdbWorkerAsText = {
   name: "duckdb-worker-as-text",
   setup(build) {
     build.onLoad(
       { filter: /@duckdb[\\\/]duckdb-wasm[\\\/]dist[\\\/]duckdb-browser-(eh|mvp)\.worker\.js$/ },
-      async (args) => ({
-        contents: await fs.readFile(args.path, "utf8"),
-        loader: "text",
-      }),
+      async (args) => {
+        const raw = await fs.readFile(args.path, "utf8");
+        const stripped = raw.replace(STRIP_EMSCRIPTEN_SCRIPT_LOADER, ASYNC_LOAD_SCRIPT_STUB);
+        if (stripped === raw) {
+          throw new Error(
+            `esbuild config: _emscripten_async_load_script strip pattern did not match ${args.path}; ` +
+              `the duckdb-wasm build may have changed shape. Inspect and update the regex.`,
+          );
+        }
+        return { contents: stripped, loader: "text" };
+      },
     );
   },
 };

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -176,7 +176,9 @@ export class SettingsTab extends PluginSettingTab {
 
     new Setting(this.containerEl)
       .setName("Auto-refresh scheduled notes")
-      .setDesc("When on, opted-in notes refresh automatically based on their cadence.")
+      .setDesc(
+        "When on, opted-in notes re-run their queries on their cadence (hourly sweep while Obsidian is open). `motherduck` blocks make network calls to your MotherDuck workspace during these refreshes; `duckdb` blocks stay local.",
+      )
       .addToggle((t) =>
         t.setValue(this.plugin.settings.scheduleEnabled).onChange(async (v) => {
           this.plugin.settings.scheduleEnabled = v;


### PR DESCRIPTION
## Summary

Two follow-up findings from the Community dashboard's scan of 0.1.3 that didn't get fixed in PR #10 (these commits were pushed to that branch but landed after its merge). Picked onto a fresh branch off main.

### 1. Disclose scheduled-refresh network behavior (commit 1)

The scanner heuristic *"Plugin combines setInterval with network calls. May perform periodic background data transmission."* fires on our scheduled-refresh sweep, even though the network calls are just the user's own MotherDuck queries re-running on their cadence. Addressed via two disclosure surfaces:

- **README** — replaced the old "Remote assets" section with a "Network access" section that has a 4-row table listing every network call the plugin makes (what / when / where / what's sent), states there is no telemetry, and notes that scheduled refresh is off by default and opt-in per note.
- **Settings copy** — the "Auto-refresh scheduled notes" toggle description now states that `motherduck` blocks make network calls during refresh while `duckdb` blocks stay local. The toggle becomes the user's consent surface.

The heuristic warning may still appear on the scorecard (it's pattern-based, not pass/fail), but with the disclosure it stops being a concerning unknown.

### 2. Strip dead Emscripten script-loader from worker bundle (commit 2)

The scanner *"Found 2 dynamic <script> element creations"* warning. Not our code — it's the Emscripten runtime helper `_emscripten_async_load_script` bundled inside DuckDB's WASM workers (one occurrence per worker: MVP and EH). The helper:

- Lives in worker context where `document` doesn't exist — so reaching its `document.createElement("script")` would throw immediately
- Is generic Emscripten -sASYNCIFY boilerplate; DuckDB-wasm's actual code paths never invoke it. The wasm imports table references the symbol but nothing calls it through that table either.

Build fix: `esbuild.config.mjs` now runs a regex replacement on the worker text before bundling, swapping the function body for a throw stub while keeping the symbol bound (so the imports-table reference stays valid). After the replacement, `grep -c 'document.createElement("script")' main.js` returns **0** (was 2). Runtime behavior is identical because the original code was unreachable.

Defensive touch: the build script **hard-fails** if the regex doesn't match either worker — so if a future `@duckdb/duckdb-wasm` ships a differently-shaped Emscripten runtime, we find out at build time instead of silently re-introducing the warning.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 31/31 pass
- [x] `npm run build` — clean; `grep -c 'document.createElement("script")' main.js` returns 0
- [ ] After merge: bump to 0.1.4, push tag, dashboard re-scan should show 0 errors + 0 dynamic-script warnings. Setinterval+network heuristic will likely still appear but with the disclosure it's no longer an unknown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)