### PR TITLE
Rename plugin to "DuckDB and MotherDuck" (drop ampersand)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ One click: **[Add to Obsidian](obsidian://show-plugin?id=duckdb-motherduck)** �
 Or manually:
 
 1. In Obsidian, open **Settings → Community plugins → Browse**.
-2. Search for **DuckDB & MotherDuck** and click **Install**, then **Enable**.
+2. Search for **DuckDB and MotherDuck** and click **Install**, then **Enable**.
 
 That's it for the standard path. Obsidian's update channel handles new releases automatically.
 
@@ -100,7 +100,7 @@ That's it for the standard path. Obsidian's update channel handles new releases 
 1. Clone this repo.
 2. `npm install && npm run build`, produces `main.js`.
 3. Copy `main.js`, `manifest.json`, and `styles.css` into `<your-vault>/.obsidian/plugins/duckdb-motherduck/`.
-4. In Obsidian: Settings → Community plugins → enable *DuckDB & MotherDuck*.
+4. In Obsidian: Settings → Community plugins → enable *DuckDB and MotherDuck*.
 
 ## Commands
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "id": "duckdb-motherduck",
-  "name": "DuckDB & MotherDuck",
+  "name": "DuckDB and MotherDuck",
   "version": "0.1.7",
   "minAppVersion": "1.5.0",
   "description": "Run DuckDB SQL inside notes. Freeze query results inline as markdown tables. Optional MotherDuck token for cloud queries.",


### PR DESCRIPTION
## Why

The Obsidian community directory flagged the plugin's display name **"DuckDB & MotherDuck"** as *not allowed*, hiding the plugin until the `name` in `manifest.json` is changed. The most likely trigger is the special character (`&`), which Obsidian's guidelines steer authors away from.

## What

- `manifest.json`: `name` → `"DuckDB and MotherDuck"`
- `README.md`: update the two install-instruction references so the searchable name matches the directory listing

The plugin `id` (`duckdb-motherduck`) is **unchanged**, so settings/data are unaffected.

## Follow-up

If the directory bounces it again after this, the flag is the third-party trademark ("DuckDB"), not the ampersand — in which case we'd move to a function-descriptive name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)