### PR TITLE
Fix DATE/TIMESTAMP/TIME columns rendering as Unix timestamps

### DIFF
--- a/src/runtime/duckdb.ts
+++ b/src/runtime/duckdb.ts
@@ -7,7 +7,7 @@ import {
 } from "@duckdb/duckdb-wasm";
 import workerEh from "@duckdb/duckdb-wasm/dist/duckdb-browser-eh.worker.js";
 import workerMvp from "@duckdb/duckdb-wasm/dist/duckdb-browser-mvp.worker.js";
-import { Row, QueryResult, Runtime, normalizeValue } from "./index";
+import { Row, QueryResult, Runtime, normalizeValue, ArrowTypeLike } from "./index";
 
 // Electron's renderer exposes Node's `require` on the main renderer's
 // `window`. Used to read real disk files for read-only queries via
@@ -146,10 +146,17 @@ export class DuckDBWasmRuntime implements Runtime {
 
     if (rowCap === undefined) {
       const table = await this.conn!.query(sql);
-      const columns = table.schema.fields.map((f) => f.name);
+      const fields = table.schema.fields;
+      const columns = fields.map((f) => f.name);
+      // Pass each column's Arrow type so temporal values (DATE/TIMESTAMP/TIME
+      // arrive as raw epoch numbers from Arrow JS) get formatted, not echoed
+      // as Unix timestamps.
+      const types = fields.map((f) => f.type as unknown as ArrowTypeLike);
       const rows: Row[] = table.toArray().map((r: Record<string, unknown>) => {
         const obj: Row = {};
-        for (const c of columns) obj[c] = normalizeValue(r[c]);
+        columns.forEach((c, i) => {
+          obj[c] = normalizeValue(r[c], types[i]);
+        });
         return obj;
       });
       return { rows, columns, truncated: false };
@@ -165,7 +172,9 @@ export class DuckDBWasmRuntime implements Runtime {
     // not populated until the reader has been opened. Calling .open() here
     // also returns the same reader with its schema attached.
     const opened = await stream.open();
-    const columns = (stream.schema ?? opened.schema).fields.map((f) => f.name);
+    const fields = (stream.schema ?? opened.schema).fields;
+    const columns = fields.map((f) => f.name);
+    const types = fields.map((f) => f.type as unknown as ArrowTypeLike);
     const rows: Row[] = [];
 
     try {
@@ -176,7 +185,9 @@ export class DuckDBWasmRuntime implements Runtime {
         for (const r of batchRows) {
           if (rows.length >= limit) break;
           const obj: Row = {};
-          for (const c of columns) obj[c] = normalizeValue(r[c]);
+          columns.forEach((c, i) => {
+            obj[c] = normalizeValue(r[c], types[i]);
+          });
           rows.push(obj);
         }
       }

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -25,12 +25,144 @@ export interface Runtime {
   label(): string;
 }
 
+// Structural view of an Arrow DataType — just enough to detect and convert
+// temporal columns. Structural (rather than apache-arrow's DataType class) so
+// tests and callers can also pass plain objects.
+export interface ArrowTypeLike {
+  typeId: number;
+  unit?: number;
+  timezone?: string | null;
+  children?: ReadonlyArray<{ name: string; type: ArrowTypeLike }> | null;
+}
+
+// Arrow `Type` / `TimeUnit` enum values (stable across apache-arrow majors).
+// Local constants instead of importing apache-arrow so this module stays
+// import-light for the MotherDuck runtime and tests.
+const ARROW_TYPE = {
+  Date: 8,
+  Time: 9,
+  Timestamp: 10,
+  List: 12,
+  Struct: 13,
+} as const;
+const ARROW_TIME_UNIT = {
+  SECOND: 0,
+  MILLISECOND: 1,
+  MICROSECOND: 2,
+  NANOSECOND: 3,
+} as const;
+
+function epochMs(v: unknown): number | null {
+  if (v instanceof Date) return v.getTime();
+  if (typeof v === "number" && Number.isFinite(v)) return v;
+  if (typeof v === "bigint") return Number(v);
+  return null;
+}
+
+// DATE has no time component; Arrow encodes it as UTC midnight, so the UTC
+// date fields are exactly the stored date. 1780272000000 -> "2026-06-01".
+function formatArrowDate(v: unknown): unknown {
+  const ms = epochMs(v);
+  if (ms === null) return v;
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+// Match DuckDB's own rendering: "YYYY-MM-DD HH:MM:SS[.mmm]", plus "+00" for
+// TIMESTAMPTZ (Arrow normalizes tz-aware values to UTC). Arrow hands us epoch
+// milliseconds regardless of the column's unit, so sub-millisecond precision
+// is already gone by the time the value reaches JS.
+function formatArrowTimestamp(v: unknown, hasTimezone: boolean): unknown {
+  const ms = epochMs(v);
+  if (ms === null) return v;
+  let s = new Date(ms).toISOString().replace("T", " ").slice(0, -1);
+  if (s.endsWith(".000")) s = s.slice(0, -4);
+  return hasTimezone ? `${s}+00` : s;
+}
+
+// TIME arrives as an integer in the column's unit (bigint for micro/nano,
+// number for second/milli). Render as "HH:MM:SS[.ffffff]".
+function formatArrowTime(v: unknown, unit?: number): unknown {
+  let raw: bigint;
+  if (typeof v === "bigint") raw = v;
+  else if (typeof v === "number" && Number.isFinite(v)) raw = BigInt(Math.trunc(v));
+  else return v;
+  if (raw < 0n) return v;
+
+  let micros: bigint;
+  switch (unit) {
+    case ARROW_TIME_UNIT.SECOND:
+      micros = raw * 1_000_000n;
+      break;
+    case ARROW_TIME_UNIT.MILLISECOND:
+      micros = raw * 1_000n;
+      break;
+    case ARROW_TIME_UNIT.NANOSECOND:
+      micros = raw / 1_000n;
+      break;
+    default:
+      // MICROSECOND — DuckDB's TIME unit.
+      micros = raw;
+  }
+
+  const pad = (n: bigint) => String(n).padStart(2, "0");
+  const hh = pad(micros / 3_600_000_000n);
+  const mm = pad((micros / 60_000_000n) % 60n);
+  const ss = pad((micros / 1_000_000n) % 60n);
+  const frac = micros % 1_000_000n;
+  const fracStr =
+    frac > 0n ? `.${String(frac).padStart(6, "0").replace(/0+$/, "")}` : "";
+  return `${hh}:${mm}:${ss}${fracStr}`;
+}
+
 // DuckDB and MotherDuck both return values that can be awkward to render or
 // serialize directly: bigint, Arrow vectors, and custom MotherDuck value
 // objects. Normalize at the runtime boundary so the UI and frozen markdown only
 // deal with plain display values.
-export function normalizeValue(v: unknown): unknown {
+//
+// Arrow JS (>=14, bundled by DuckDB-Wasm) returns temporal values as raw
+// numbers — DATE and TIMESTAMP as epoch milliseconds, TIME as an integer in
+// the column's unit — which are indistinguishable from numeric columns
+// without the schema. Callers that have the Arrow schema pass the column
+// `type` so those values can be formatted as dates/timestamps here.
+export function normalizeValue(v: unknown, type?: ArrowTypeLike): unknown {
   if (v === null || v === undefined) return v;
+
+  if (type) {
+    switch (type.typeId) {
+      case ARROW_TYPE.Date:
+        return formatArrowDate(v);
+      case ARROW_TYPE.Timestamp:
+        return formatArrowTimestamp(v, Boolean(type.timezone));
+      case ARROW_TYPE.Time:
+        return formatArrowTime(v, type.unit);
+      case ARROW_TYPE.List: {
+        const child = type.children?.[0]?.type;
+        const items = Array.isArray(v)
+          ? v
+          : typeof (v as { toArray?: unknown }).toArray === "function"
+            ? (v as { toArray: () => Iterable<unknown> }).toArray()
+            : null;
+        if (items) {
+          return Array.from(items, (item) => normalizeValue(item, child));
+        }
+        break;
+      }
+      case ARROW_TYPE.Struct: {
+        if (typeof v === "object" && type.children?.length) {
+          const out: Row = {};
+          for (const { name, type: childType } of type.children) {
+            out[name] = normalizeValue(
+              (v as Record<string, unknown>)[name],
+              childType,
+            );
+          }
+          return out;
+        }
+        break;
+      }
+    }
+  }
+
   if (typeof v === "bigint") return v.toString();
   if (v instanceof Date) return v.toISOString();
   if (v instanceof Uint8Array) return `<${v.length} bytes>`;

--- a/test/runtime-values.test.ts
+++ b/test/runtime-values.test.ts
@@ -1,5 +1,15 @@
 import { strict as assert } from "node:assert";
 import { test } from "node:test";
+import {
+  vectorFromArray,
+  DateDay,
+  Field,
+  List,
+  Struct,
+  TimeMicrosecond,
+  TimeMillisecond,
+  TimestampMicrosecond,
+} from "apache-arrow";
 import { normalizeValue } from "../src/runtime";
 
 test("normalizeValue converts non-JSON primitives and nested values", () => {
@@ -21,4 +31,68 @@ test("normalizeValue uses custom DuckDB value stringification", () => {
   };
 
   assert.equal(normalizeValue(value), "00:00:00.000123");
+});
+
+// Issue #18: Arrow JS (>=14, bundled by DuckDB-Wasm) returns DATE columns as
+// epoch-millisecond numbers, which the plugin rendered verbatim as Unix
+// timestamps. With the column's Arrow type, normalizeValue formats them.
+test("normalizeValue formats Arrow DATE columns as YYYY-MM-DD", () => {
+  const vec = vectorFromArray([new Date(Date.UTC(2026, 5, 1))], new DateDay());
+  const raw = vec.get(0);
+  // The exact symptom from the issue: a 13-digit epoch-ms number.
+  assert.equal(raw, 1780272000000);
+  assert.equal(normalizeValue(raw, vec.type), "2026-06-01");
+});
+
+test("normalizeValue formats Arrow TIMESTAMP columns as readable timestamps", () => {
+  const ts = vectorFromArray(
+    [new Date("2026-06-01T12:34:56.789Z")],
+    new TimestampMicrosecond(),
+  );
+  assert.equal(typeof ts.get(0), "number");
+  assert.equal(normalizeValue(ts.get(0), ts.type), "2026-06-01 12:34:56.789");
+
+  // Whole-second values drop the ".000".
+  const whole = vectorFromArray(
+    [new Date("2026-06-01T12:34:56Z")],
+    new TimestampMicrosecond(),
+  );
+  assert.equal(normalizeValue(whole.get(0), whole.type), "2026-06-01 12:34:56");
+
+  // TIMESTAMPTZ: Arrow normalizes to UTC; render with an explicit offset.
+  assert.equal(
+    normalizeValue(ts.get(0), new TimestampMicrosecond("UTC")),
+    "2026-06-01 12:34:56.789+00",
+  );
+});
+
+test("normalizeValue formats Arrow TIME columns as HH:MM:SS", () => {
+  // DuckDB TIME is microsecond-unit; Arrow JS hands it over as bigint micros.
+  const micros = new TimeMicrosecond();
+  assert.equal(normalizeValue(45_296_000_000n, micros), "12:34:56");
+  assert.equal(normalizeValue(45_296_789_000n, micros), "12:34:56.789");
+  assert.equal(normalizeValue(0n, micros), "00:00:00");
+  // Millisecond-unit times arrive as plain numbers.
+  assert.equal(normalizeValue(45_296_789, new TimeMillisecond()), "12:34:56.789");
+});
+
+test("normalizeValue formats dates nested in LIST and STRUCT columns", () => {
+  const list = vectorFromArray(
+    [[new Date(Date.UTC(2026, 5, 1))]],
+    new List(new Field("item", new DateDay())),
+  );
+  assert.deepEqual(normalizeValue(list.get(0), list.type), ["2026-06-01"]);
+
+  const struct = vectorFromArray(
+    [{ d: new Date(Date.UTC(2026, 5, 1)) }],
+    new Struct([new Field("d", new DateDay())]),
+  );
+  assert.deepEqual(normalizeValue(struct.get(0), struct.type), {
+    d: "2026-06-01",
+  });
+});
+
+test("normalizeValue without a column type keeps legacy behavior", () => {
+  // Plain numeric columns (no Arrow type passed) must not be reinterpreted.
+  assert.equal(normalizeValue(1780272000000), 1780272000000);
 });


### PR DESCRIPTION
Fixes #18

## Root cause

Arrow JS changed behavior in v14 — temporal values are no longer returned as `Date` objects but as raw numbers. DuckDB-Wasm (pinned at `1.33.1-dev50.0`) bundles Arrow v17, so:

- `DATE` / `TIMESTAMP` columns arrive as epoch-**millisecond numbers** (the exact `1780272000000` from the issue = `2026-06-01`)
- `TIME` columns arrive as bigint microseconds

`normalizeValue()` only handled `v instanceof Date`, so these numbers were indistinguishable from numeric columns and rendered verbatim. This is also why the reporter's `to_timestamp` / `epoch_ms` workarounds didn't help — `TIMESTAMP` had the same problem.

The MotherDuck cloud runtime is unaffected: its wasm-client wraps temporal values in objects with a custom `toString`, which was already handled.

## Fix

The Arrow schema is the only place the type information survives, so normalization is now schema-aware:

- `src/runtime/index.ts` — `normalizeValue(v, type?)` accepts an optional structural `ArrowTypeLike` and formats:
  - `DATE` → `2026-06-01`
  - `TIMESTAMP` → `2026-06-01 12:34:56.789` (drops `.000`; `TIMESTAMPTZ` gets a `+00` suffix, matching DuckDB's own rendering)
  - `TIME` → `12:34:56[.ffffff]` (all four Arrow time units)
  - `LIST` / `STRUCT` → recurses with child types so nested dates format too
  - no type passed → exact legacy behavior (MotherDuck path untouched)
- `src/runtime/duckdb.ts` — both the materializing and streaming query paths pass each column's Arrow `field.type` into `normalizeValue`.

## Tests

5 new tests in `test/runtime-values.test.ts` built on **real apache-arrow vectors** (the same library duckdb-wasm bundles), including a regression test asserting the raw Arrow value is the literal `1780272000000` from the issue before formatting — if Arrow's value representation changes again, the test catches it.

`npm test`: 36/36 pass. Lint, typecheck, and production build clean.