### PR TITLE
Add workflow_dispatch release flow (no more local pushes to main)

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -1,0 +1,74 @@
+name: Cut release
+
+# Manual release entry point: Actions tab -> "Cut release" -> Run workflow.
+# Bumps the version on main (npm version runs version-bump.mjs, which mirrors
+# the new version into manifest.json and versions.json), pushes the commit and
+# tag as the actions bot, then calls release.yml to build and attach a draft
+# release. Nothing is published automatically: edit the draft's notes and
+# publish it by hand.
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump"
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
+# One release at a time; a second click queues instead of racing the push.
+concurrency:
+  group: cut-release
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.bump.outputs.tag }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Gate the bump on a green tree so a broken main never gets tagged.
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test
+
+      - name: Bump version and tag
+        id: bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          npm version "${{ inputs.bump }}"
+          echo "tag=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Push version commit and tag
+        run: git push origin main --follow-tags
+
+  release:
+    needs: bump
+    uses: ./.github/workflows/release.yml
+    with:
+      tag: ${{ needs.bump.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,21 @@
 name: Release Obsidian plugin
 
+# Runs in two ways:
+#   1. A tag is pushed manually (legacy path).
+#   2. Called by cut-release.yml after it bumps the version and pushes the
+#      tag. The explicit workflow_call is required because tags pushed with
+#      the default GITHUB_TOKEN do not fire `on: push: tags` (GitHub's
+#      anti-recursion rule).
 on:
   push:
     tags:
       - "*"
+  workflow_call:
+    inputs:
+      tag:
+        description: "Existing tag to build and draft a release for (e.g. 0.1.9)"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -16,6 +28,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # On tag pushes inputs.tag is empty and github.ref is the tag. When
+          # called from cut-release.yml the calling ref predates the version
+          # commit, so check out the freshly pushed tag instead.
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -46,8 +63,9 @@ jobs:
       - name: Create draft release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          tag="${GITHUB_REF#refs/tags/}"
+          tag="${INPUT_TAG:-${GITHUB_REF#refs/tags/}}"
           gh release create "$tag" \
             --title="$tag" \
             --draft \

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+tag-version-prefix=""


### PR DESCRIPTION
Cutting a release previously meant running `npm version` locally and pushing the version commit + tag straight to main. This adds a **"Cut release"** button in the Actions tab instead.

## How it works

`cut-release.yml` (new, `workflow_dispatch`):
1. Checks out `main`, runs **lint + test** as a gate — a broken main never gets tagged
2. `npm version <patch|minor|major>` (input, defaults to `patch`) — this runs the existing `version-bump.mjs` hook, mirroring the version into `manifest.json` + `versions.json`
3. Pushes the version commit + tag as `github-actions[bot]`
4. Calls `release.yml` to build, attest, and create the **draft** release with `main.js` / `manifest.json` / `styles.css`

Publishing stays manual: edit the draft's notes and publish by hand, same as today.

## Why `release.yml` needed a `workflow_call` trigger

Tags pushed with the default `GITHUB_TOKEN` do **not** fire `on: push: tags` (GitHub's anti-recursion rule), so the dispatch workflow must invoke the release build explicitly. Manually pushed tags still trigger it exactly as before. When called, it checks out the freshly pushed tag (the calling ref predates the version commit).

## Why `.npmrc` is now committed

It carries `tag-version-prefix=""` so CI's `npm version` produces `0.1.9`-style tags matching the existing scheme instead of `v0.1.9`.

## Releasing 0.1.9

After merging: Actions → **Cut release** → Run workflow → `patch`. That cuts `0.1.9` with the #18 date-rendering fix.

Also added a `concurrency` group so two clicks queue instead of racing the push.