### PR TITLE
Read vault files in duckdb blocks via registered buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The plugin reads the file through Obsidian's vault API (so it also works on mobi
 
 Limits worth knowing:
 
-- **The whole file is loaded into memory** in the Obsidian process. There's a size cap — *Settings → Max local file size* (default 1024 MB); above it the query is refused, because exhausting memory can crash the window. For larger data, read it over a **URL** (`https://…`, range-read by httpfs, nothing held whole) or push it to **MotherDuck**.
+- **The referenced files are loaded into memory** in the Obsidian process while the query runs. There's a combined size cap — *Settings → Max local query data* (default 1024 MB); above it the query is refused before any file is read, because exhausting memory can crash the window. For larger data, read it over a **URL** (`https://…`, range-read by httpfs, nothing held whole) or push it to **MotherDuck**.
 - **Globs** (`data/*.csv`) and **absolute paths outside the vault** aren't handled by the vault bridge. Use a URL for those, or the read-only [DuckDB file path](#connections) setting for an on-disk `.duckdb` database.
 - Cloud (`motherduck`) blocks don't read vault files — that would mean uploading. Keep local files on `duckdb`.
 
@@ -139,7 +139,7 @@ From the command palette:
 - **Scheduled refresh**: see the next section.
 - **General → Row cap**: max rows rendered inline or written into a frozen table. The runtime stops scanning at `rowCap + 1` rows and discards the rest, so heavy queries (`FROM 'huge.csv'`) don't materialize 40k rows in WASM heap just to throw 39 900 of them away. A truncation notice is appended if more rows existed.
 - **General → Cell character cap**: max characters per cell in rendered and frozen tables; longer values are truncated with an ellipsis. Hover a truncated cell in the live result to see the full value. Default `80`.
-- **DuckDB → Max local file size (MB)**: cap on a vault file a `duckdb` query will load into memory (default `1024`). Above it the query is refused — see [Reading files from your vault](#reading-files-from-your-vault). Set `0` to disable the limit (you accept the out-of-memory risk).
+- **DuckDB → Max local query data (MB)**: cap on the combined vault files a `duckdb` query will load into memory (default `1024`). Above it the query is refused before reading any file — see [Reading files from your vault](#reading-files-from-your-vault). Set `0` to disable the limit (you accept the out-of-memory risk).
 
 ## Scheduled refresh
 
@@ -220,7 +220,7 @@ Queries run locally (`duckdb` blocks) or against your MotherDuck account (`mothe
 ## Known limitations
 
 - **No mobile validation**, the architecture should work in mobile Obsidian for `:memory:` and OPFS modes (vault-file reads use the cross-platform vault API and should work on mobile too), but hasn't been tested on iOS/Android. Absolute-path mode requires Node integration which isn't available on mobile.
-- **Vault-file reads are size-capped and in-memory**: the file is loaded whole into the renderer, so large files are refused above *Max local file size*. Globs and absolute paths outside the vault aren't supported through the vault bridge — use a URL or MotherDuck. See [Reading files from your vault](#reading-files-from-your-vault).
+- **Vault-file reads are size-capped and in-memory**: referenced files are loaded into the renderer while the query runs, so queries above the combined *Max local query data* limit are refused. Globs and absolute paths outside the vault aren't supported through the vault bridge — use a URL or MotherDuck. See [Reading files from your vault](#reading-files-from-your-vault).
 - **Read-only for on-disk files**, pointing at a real `.duckdb` file lets you query it, but writes (`CREATE` / `INSERT` / `UPDATE`) succeed only inside the worker and don't persist back to the file.
 - **Scheduled refresh runs only while Obsidian is open.** If you want notes refreshed while your laptop is asleep or Obsidian is closed, you need an external trigger (e.g. cron + the Obsidian CLI calling the plugin's API).
 - **No keychain integration for the MotherDuck token**, stored plaintext in `data.json`. See *Security*.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Bring **external data** into your Obsidian notes via DuckDB SQL, then freeze the
 
 Works entirely offline with local DuckDB WASM. Add a MotherDuck token to query your cloud data alongside, picking per code block which connection to use.
 
-- **Query any local or remote file**: Parquet, CSV, JSON, Excel, Iceberg, Delta, geospatial. Anything DuckDB reads.
+- **Query files in your vault or over the web**: read a CSV/Parquet/JSON sitting next to your note (`read_csv('data/sales.csv')`) or any remote URL. Plus Excel, Iceberg, Delta, geospatial — anything DuckDB reads.
 - **Cache results inline as markdown**: freeze the query output right under the SQL so the note becomes a self-contained document, readable in any editor.
 - **Scheduled refresh**: pick a daily or weekly cadence per note; the plugin re-runs the queries automatically while Obsidian is open.
 - **MotherDuck for cloud data and compute**: add a token to query cloud databases or push heavy SQL onto MotherDuck instead of your laptop.
@@ -34,6 +34,24 @@ In reading mode the block becomes a SQL panel with **Run** / **Freeze** / **Clea
 Add a [MotherDuck token](#install) in Settings to enable `motherduck` blocks against cloud databases or heavier compute:
 
 ![Rendered MotherDuck block with frozen result](docs/images/demo_obsidian_motherduck.png)
+
+## Reading files from your vault
+
+A `duckdb` block can read data files stored **in your vault** — drop a CSV/Parquet/JSON next to your note and query it by name:
+
+````markdown
+```duckdb
+SELECT country, count(*) AS cities FROM read_csv('data/cities.csv') GROUP BY 1
+```
+````
+
+The plugin reads the file through Obsidian's vault API (so it also works on mobile, unlike the absolute-path DuckDB-file setting) and hands the bytes to the local engine before the query runs. Paths resolve **relative to the note first**, then the vault root. Supported across `read_csv`, `read_parquet`, `read_json`, `read_ndjson` (and their `_auto` variants), plus bare `FROM 'file.parquet'`.
+
+Limits worth knowing:
+
+- **The whole file is loaded into memory** in the Obsidian process. There's a size cap — *Settings → Max local file size* (default 1024 MB); above it the query is refused, because exhausting memory can crash the window. For larger data, read it over a **URL** (`https://…`, range-read by httpfs, nothing held whole) or push it to **MotherDuck**.
+- **Globs** (`data/*.csv`) and **absolute paths outside the vault** aren't handled by the vault bridge. Use a URL for those, or the read-only [DuckDB file path](#connections) setting for an on-disk `.duckdb` database.
+- Cloud (`motherduck`) blocks don't read vault files — that would mean uploading. Keep local files on `duckdb`.
 
 ## Why this and not Dataview?
 
@@ -121,6 +139,7 @@ From the command palette:
 - **Scheduled refresh**: see the next section.
 - **General → Row cap**: max rows rendered inline or written into a frozen table. The runtime stops scanning at `rowCap + 1` rows and discards the rest, so heavy queries (`FROM 'huge.csv'`) don't materialize 40k rows in WASM heap just to throw 39 900 of them away. A truncation notice is appended if more rows existed.
 - **General → Cell character cap**: max characters per cell in rendered and frozen tables; longer values are truncated with an ellipsis. Hover a truncated cell in the live result to see the full value. Default `80`.
+- **DuckDB → Max local file size (MB)**: cap on a vault file a `duckdb` query will load into memory (default `1024`). Above it the query is refused — see [Reading files from your vault](#reading-files-from-your-vault). Set `0` to disable the limit (you accept the out-of-memory risk).
 
 ## Scheduled refresh
 
@@ -200,7 +219,8 @@ Queries run locally (`duckdb` blocks) or against your MotherDuck account (`mothe
 
 ## Known limitations
 
-- **No mobile validation**, the architecture should work in mobile Obsidian for `:memory:` and OPFS modes, but hasn't been tested on iOS/Android. Absolute-path mode requires Node integration which isn't available on mobile.
+- **No mobile validation**, the architecture should work in mobile Obsidian for `:memory:` and OPFS modes (vault-file reads use the cross-platform vault API and should work on mobile too), but hasn't been tested on iOS/Android. Absolute-path mode requires Node integration which isn't available on mobile.
+- **Vault-file reads are size-capped and in-memory**: the file is loaded whole into the renderer, so large files are refused above *Max local file size*. Globs and absolute paths outside the vault aren't supported through the vault bridge — use a URL or MotherDuck. See [Reading files from your vault](#reading-files-from-your-vault).
 - **Read-only for on-disk files**, pointing at a real `.duckdb` file lets you query it, but writes (`CREATE` / `INSERT` / `UPDATE`) succeed only inside the worker and don't persist back to the file.
 - **Scheduled refresh runs only while Obsidian is open.** If you want notes refreshed while your laptop is asleep or Obsidian is closed, you need an external trigger (e.g. cron + the Obsidian CLI calling the plugin's API).
 - **No keychain integration for the MotherDuck token**, stored plaintext in `data.json`. See *Security*.

--- a/docs/data/cities.csv
+++ b/docs/data/cities.csv
@@ -1,0 +1,6 @@
+city,country,population
+Tokyo,JP,37400068
+Delhi,IN,28514000
+Shanghai,CN,25582000
+Paris,FR,11017000
+London,GB,9046000

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -170,3 +170,17 @@ ORDER BY revenue DESC
 | AIR | 8491 | 303207759.31 |
 
 <!-- md:cache-end -->
+
+
+## 6. Pure DuckDB, read a CSV from your vault
+
+This block reads a file that lives **inside the vault**, next to this note at [`data/cities.csv`](data/cities.csv). The plugin reads the file through Obsidian's vault API and hands the bytes to DuckDB-WASM, so the path is resolved relative to this note (vault root is also tried). Works offline, no token, and works on mobile too. Paths are resolved relative to the note first, then the vault root.
+
+```duckdb
+SELECT country, count(*) AS cities, sum(population) AS people
+FROM read_csv('data/cities.csv')
+GROUP BY 1
+ORDER BY people DESC
+```
+
+> The whole file is loaded into memory in the Obsidian process, so there's a size cap (**Settings → Max local file size**, default 1024 MB). For larger data, read it over a URL (httpfs) or push it to MotherDuck. Globs (`data/*.csv`) and absolute paths outside the vault aren't supported here — use a URL or the read-only DuckDB file path for those.

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -183,4 +183,4 @@ GROUP BY 1
 ORDER BY people DESC
 ```
 
-> The whole file is loaded into memory in the Obsidian process, so there's a size cap (**Settings → Max local file size**, default 1024 MB). For larger data, read it over a URL (httpfs) or push it to MotherDuck. Globs (`data/*.csv`) and absolute paths outside the vault aren't supported here — use a URL or the read-only DuckDB file path for those.
+> Referenced files are loaded into memory in the Obsidian process while the query runs, so there's a combined size cap (**Settings → Max local query data**, default 1024 MB). For larger data, read it over a URL (httpfs) or push it to MotherDuck. Globs (`data/*.csv`) and absolute paths outside the vault aren't supported here — use a URL or the read-only DuckDB file path for those.

--- a/main.ts
+++ b/main.ts
@@ -212,7 +212,7 @@ export default class MotherDuckPlugin extends Plugin {
 
     const adapter = this.app.vault.adapter;
     const capBytes = this.settings.maxLocalFileMB * 1024 * 1024;
-    const out: Array<{ name: string; bytes: Uint8Array }> = [];
+    const resolvedFiles: Array<{ literal: string; resolved: string; size: number }> = [];
 
     for (const literal of literals) {
       let resolved: string | null = null;
@@ -225,28 +225,34 @@ export default class MotherDuckPlugin extends Plugin {
       if (!resolved) continue; // not a vault file — let DuckDB try (URL/error)
 
       const stat = await adapter.stat(resolved);
-      const size = stat?.size ?? 0;
-      if (capBytes > 0 && size > capBytes) {
-        const mb = (size / (1024 * 1024)).toFixed(0);
-        throw new Error(
-          `Local file '${literal}' is ${mb} MB, over the ${this.settings.maxLocalFileMB} MB limit. ` +
-            `It would be loaded fully into memory. Raise "Max local file size" in settings, ` +
-            `or query it via a URL (httpfs) or MotherDuck instead.`,
-        );
-      }
-      if (size > LOCAL_FILE_WARN_MB * 1024 * 1024) {
-        new Notice(
-          `Loading ${(size / (1024 * 1024)).toFixed(0)} MB '${literal}' into memory…`,
-        );
-      }
-
-      const buf = await adapter.readBinary(resolved);
-      // Register under the exact literal the user wrote, so their SQL runs
-      // unchanged (DuckDB resolves registered names before the filesystem).
-      out.push({ name: literal, bytes: new Uint8Array(buf) });
+      resolvedFiles.push({ literal, resolved, size: stat?.size ?? 0 });
     }
 
-    return out;
+    // Gate the aggregate before reading any bytes. A per-file cap still allows
+    // several individually-valid files to exhaust the renderer together.
+    const totalSize = resolvedFiles.reduce((sum, file) => sum + file.size, 0);
+    if (capBytes > 0 && totalSize > capBytes) {
+      const mb = (totalSize / (1024 * 1024)).toFixed(0);
+      throw new Error(
+        `Local files for this query total ${mb} MB, over the ${this.settings.maxLocalFileMB} MB limit. ` +
+          `They would be loaded fully into memory. Raise "Max local query data" in settings, ` +
+          `or query via a URL (httpfs) or MotherDuck instead.`,
+      );
+    }
+    if (totalSize > LOCAL_FILE_WARN_MB * 1024 * 1024) {
+      new Notice(
+        `Loading ${(totalSize / (1024 * 1024)).toFixed(0)} MB of local query data into memory…`,
+      );
+    }
+
+    return Promise.all(
+      resolvedFiles.map(async ({ literal, resolved }) => {
+        const buf = await adapter.readBinary(resolved);
+        // Register under the decoded SQL literal, which is the filename DuckDB
+        // resolves after parsing the query.
+        return { name: literal, bytes: new Uint8Array(buf) };
+      }),
+    );
   }
 
   startScheduler() {

--- a/main.ts
+++ b/main.ts
@@ -7,6 +7,11 @@ import {
   type FencedBlock,
 } from "./src/markdown";
 import { renderQueryBlock } from "./src/query-block";
+import {
+  candidateVaultPaths,
+  extractFileLiterals,
+  isVaultCandidate,
+} from "./src/local-files";
 import { RuntimeManager } from "./src/runtime/manager";
 import { consecutiveAllErrorFailures, isOverdue } from "./src/schedule";
 import { SettingsTab } from "./src/settings-tab";
@@ -14,6 +19,7 @@ import { renderMarkdownTable } from "./src/table";
 import {
   AUTO_DISABLE_FAILURE_THRESHOLD,
   DEFAULTS,
+  LOCAL_FILE_WARN_MB,
   LOG_CAP,
   STARTUP_DELAY_MS,
   SWEEP_INTERVAL_MS,
@@ -182,8 +188,65 @@ export default class MotherDuckPlugin extends Plugin {
     sql: string,
     connection: Connection,
     rowCap?: number,
+    sourcePath?: string,
   ): Promise<QueryRunResult> {
-    return this.runtimeManager.runQuery(sql, connection, rowCap);
+    // Only the local DuckDB engine reads vault files; cloud queries run on
+    // MotherDuck and can't see the laptop's files.
+    const files =
+      connection === "local"
+        ? await this.resolveLocalFiles(sql, sourcePath)
+        : undefined;
+    return this.runtimeManager.runQuery(sql, connection, rowCap, files);
+  }
+
+  // Find file literals in the SQL that point at existing vault files, gate each
+  // on size, and read its bytes so the runtime can register them. Anything that
+  // isn't a vault file (URLs, absolute disk paths, globs, or names that don't
+  // resolve) is skipped and left for DuckDB to handle or error on.
+  private async resolveLocalFiles(
+    sql: string,
+    sourcePath?: string,
+  ): Promise<Array<{ name: string; bytes: Uint8Array }>> {
+    const literals = extractFileLiterals(sql).filter(isVaultCandidate);
+    if (literals.length === 0) return [];
+
+    const adapter = this.app.vault.adapter;
+    const capBytes = this.settings.maxLocalFileMB * 1024 * 1024;
+    const out: Array<{ name: string; bytes: Uint8Array }> = [];
+
+    for (const literal of literals) {
+      let resolved: string | null = null;
+      for (const candidate of candidateVaultPaths(literal, sourcePath)) {
+        if (await adapter.exists(candidate)) {
+          resolved = candidate;
+          break;
+        }
+      }
+      if (!resolved) continue; // not a vault file — let DuckDB try (URL/error)
+
+      const stat = await adapter.stat(resolved);
+      const size = stat?.size ?? 0;
+      if (capBytes > 0 && size > capBytes) {
+        const mb = (size / (1024 * 1024)).toFixed(0);
+        throw new Error(
+          `Local file '${literal}' is ${mb} MB, over the ${this.settings.maxLocalFileMB} MB limit. ` +
+            `It would be loaded fully into memory. Raise "Max local file size" in settings, ` +
+            `or query it via a URL (httpfs) or MotherDuck instead.`,
+        );
+      }
+      if (size > LOCAL_FILE_WARN_MB * 1024 * 1024) {
+        new Notice(
+          `Loading ${(size / (1024 * 1024)).toFixed(0)} MB '${literal}' into memory…`,
+        );
+      }
+
+      const buf = await adapter.readBinary(resolved);
+      // Register under the exact literal the user wrote, so their SQL runs
+      // unchanged (DuckDB resolves registered names before the filesystem).
+      out.push({ name: literal, bytes: new Uint8Array(buf) });
+    }
+
+    return out;
   }
 
   startScheduler() {
@@ -271,7 +334,7 @@ export default class MotherDuckPlugin extends Plugin {
       const file = this.app.vault.getAbstractFileByPath(path);
       if (!(file instanceof TFile)) throw new Error(`not a file: ${path}`);
       const content = await this.app.vault.read(file);
-      const result = await this.processAllBlocks(content);
+      const result = await this.processAllBlocks(content, file.path);
       await this.modifyIfUnchanged(file, content, result.newContent);
       return { refreshed: result.refreshed, errored: result.errored, firstError: result.firstError };
     });
@@ -283,7 +346,7 @@ export default class MotherDuckPlugin extends Plugin {
       const blocks = findBlocks(content);
       const hit = blocks.find((b) => cursorLine >= b.startLine && cursorLine <= b.endLine);
       if (!hit) throw new Error("no ```duckdb or ```motherduck block at cursor");
-      const newContent = await this.freezeBlock(content, hit);
+      const newContent = await this.freezeBlock(content, hit, file.path);
       await this.modifyIfUnchanged(file, content, newContent);
       return "Refreshed 1 block";
     });
@@ -340,13 +403,14 @@ export default class MotherDuckPlugin extends Plugin {
         findBlocks(content).find(
           (candidate) => candidate.startLine === info.lineStart && candidate.endLine === info.lineEnd,
         ) ?? { sql, startLine: info.lineStart, endLine: info.lineEnd, connection };
-      const newContent = await this.freezeBlock(content, block);
+      const newContent = await this.freezeBlock(content, block, file.path);
       await this.modifyIfUnchanged(file, content, newContent);
     });
   }
 
   async processAllBlocks(
     content: string,
+    sourcePath?: string,
   ): Promise<{ newContent: string; refreshed: number; errored: number; firstError?: string }> {
     const blocks = findBlocks(content);
     let working = content;
@@ -356,7 +420,7 @@ export default class MotherDuckPlugin extends Plugin {
 
     for (let i = blocks.length - 1; i >= 0; i--) {
       try {
-        working = await this.freezeBlock(working, blocks[i]);
+        working = await this.freezeBlock(working, blocks[i], sourcePath);
         refreshed++;
       } catch (e) {
         console.error("[motherduck] block error", e);
@@ -368,11 +432,12 @@ export default class MotherDuckPlugin extends Plugin {
     return { newContent: working, refreshed, errored, firstError };
   }
 
-  async freezeBlock(content: string, block: FencedBlock): Promise<string> {
+  async freezeBlock(content: string, block: FencedBlock, sourcePath?: string): Promise<string> {
     const { rows, columns, truncated } = await this.runQuery(
       block.sql,
       block.connection,
       this.settings.rowCap,
+      sourcePath,
     );
     const mdTable = renderMarkdownTable(
       rows,

--- a/src/local-files.ts
+++ b/src/local-files.ts
@@ -1,0 +1,94 @@
+// Pull local-file references out of a SQL query so the plugin can read those
+// files from the vault and hand their bytes to DuckDB-Wasm (which otherwise
+// has no path into the host filesystem). Pure string logic only — the actual
+// vault read / size gate / buffer registration lives in main.ts, where the
+// Obsidian app and runtime are in scope. Kept separate so it's unit-testable
+// without an Obsidian or WASM environment.
+
+// File-reading table functions DuckDB exposes. We only look at the FIRST
+// single-quoted argument; list forms (`read_csv(['a.csv','b.csv'])`) and globs
+// are intentionally out of scope for v1 (see isVaultCandidate).
+const READER_FNS = [
+  "read_csv",
+  "read_csv_auto",
+  "read_parquet",
+  "read_json",
+  "read_json_auto",
+  "read_ndjson",
+  "read_ndjson_auto",
+].join("|");
+
+const READER_RE = new RegExp(`\\b(?:${READER_FNS})\\s*\\(\\s*'([^']+)'`, "gi");
+// Bare `FROM 'file.parquet'` — DuckDB infers the reader from the extension.
+const FROM_RE = /\bfrom\s+'([^']+)'/gi;
+
+// Extract candidate file path literals from a query, de-duplicated in first-seen
+// order. Returns the raw literal exactly as written so the caller can register
+// the bytes under that same name and the SQL runs unchanged.
+export function extractFileLiterals(sql: string): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const re of [READER_RE, FROM_RE]) {
+    re.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(sql)) !== null) {
+      const lit = m[1];
+      if (!seen.has(lit)) {
+        seen.add(lit);
+        out.push(lit);
+      }
+    }
+  }
+  return out;
+}
+
+// Is this literal something we should try to read from the vault? We register
+// only vault-relative data files. Everything else is left for DuckDB to resolve
+// itself:
+//   - `scheme://...`  remote/OPFS URLs go through httpfs, no local copy needed.
+//   - absolute paths  (`/x`, `C:\x`) are real disk files, handled by the
+//                     read-only DB-file path, not the vault bridge.
+//   - globs           (`*`, `?`, `[`) expand inside the engine over its VFS;
+//                     a single registered buffer can't satisfy them. Out of
+//                     scope for v1; left to error clearly.
+export function isVaultCandidate(literal: string): boolean {
+  if (!literal) return false;
+  if (literal.includes("://")) return false;
+  if (literal.startsWith("/")) return false;
+  if (/^[A-Za-z]:[\\/]/.test(literal)) return false;
+  if (/[*?[\]]/.test(literal)) return false;
+  return true;
+}
+
+function posixDirname(p: string): string {
+  const i = p.lastIndexOf("/");
+  return i <= 0 ? "" : p.slice(0, i);
+}
+
+// Resolve `.`/`..` segments against a "/"-separated vault path. Vault paths are
+// always forward-slash and root-relative, so this is deliberately simpler than
+// Node's path (which we can't use on mobile anyway).
+export function normalizeVaultPath(p: string): string {
+  const out: string[] = [];
+  for (const part of p.split("/")) {
+    if (part === "" || part === ".") continue;
+    if (part === "..") {
+      out.pop();
+      continue;
+    }
+    out.push(part);
+  }
+  return out.join("/");
+}
+
+// Ordered vault paths to try for a literal: first relative to the note's own
+// folder (so `data/x.csv` next to the note wins), then relative to the vault
+// root. The caller picks the first that actually exists.
+export function candidateVaultPaths(literal: string, notePath?: string): string[] {
+  const lit = literal.replace(/^\.\//, "");
+  const cands: string[] = [];
+  const dir = notePath ? posixDirname(notePath) : "";
+  if (dir) cands.push(normalizeVaultPath(`${dir}/${lit}`));
+  cands.push(normalizeVaultPath(lit));
+  return [...new Set(cands)].filter((c) => c.length > 0);
+}

--- a/src/local-files.ts
+++ b/src/local-files.ts
@@ -5,10 +5,10 @@
 // Obsidian app and runtime are in scope. Kept separate so it's unit-testable
 // without an Obsidian or WASM environment.
 
-// File-reading table functions DuckDB exposes. We only look at the FIRST
+// File-reading table functions DuckDB exposes. We only look at the first
 // single-quoted argument; list forms (`read_csv(['a.csv','b.csv'])`) and globs
 // are intentionally out of scope for v1 (see isVaultCandidate).
-const READER_FNS = [
+const READER_FNS = new Set([
   "read_csv",
   "read_csv_auto",
   "read_parquet",
@@ -16,27 +16,145 @@ const READER_FNS = [
   "read_json_auto",
   "read_ndjson",
   "read_ndjson_auto",
-].join("|");
+]);
 
-const READER_RE = new RegExp(`\\b(?:${READER_FNS})\\s*\\(\\s*'([^']+)'`, "gi");
-// Bare `FROM 'file.parquet'` — DuckDB infers the reader from the extension.
-const FROM_RE = /\bfrom\s+'([^']+)'/gi;
+type SqlToken =
+  | { kind: "word"; value: string }
+  | { kind: "string"; value: string }
+  | { kind: "punct"; value: string };
 
-// Extract candidate file path literals from a query, de-duplicated in first-seen
-// order. Returns the raw literal exactly as written so the caller can register
-// the bytes under that same name and the SQL runs unchanged.
+function isWordStart(c: string): boolean {
+  return /[A-Za-z_]/.test(c);
+}
+
+function isWordPart(c: string): boolean {
+  return /[A-Za-z0-9_$]/.test(c);
+}
+
+// Tokenize only the SQL shapes needed for file extraction. Comments, quoted
+// identifiers, and dollar-quoted strings are skipped so text that merely
+// mentions `read_csv('x.csv')` cannot trigger a vault read. SQL strings are
+// decoded (`'O''Brien.csv'` -> `O'Brien.csv`) because DuckDB resolves the
+// decoded filename, not the source spelling.
+function tokenizeSql(sql: string): SqlToken[] {
+  const tokens: SqlToken[] = [];
+  let i = 0;
+
+  while (i < sql.length) {
+    const c = sql[i];
+
+    if (/\s/.test(c)) {
+      i++;
+      continue;
+    }
+
+    if (c === "-" && sql[i + 1] === "-") {
+      i += 2;
+      while (i < sql.length && sql[i] !== "\n") i++;
+      continue;
+    }
+
+    if (c === "/" && sql[i + 1] === "*") {
+      i += 2;
+      let depth = 1;
+      while (i < sql.length && depth > 0) {
+        if (sql[i] === "/" && sql[i + 1] === "*") {
+          depth++;
+          i += 2;
+        } else if (sql[i] === "*" && sql[i + 1] === "/") {
+          depth--;
+          i += 2;
+        } else {
+          i++;
+        }
+      }
+      continue;
+    }
+
+    if (c === "'") {
+      let value = "";
+      i++;
+      while (i < sql.length) {
+        if (sql[i] === "'" && sql[i + 1] === "'") {
+          value += "'";
+          i += 2;
+        } else if (sql[i] === "'") {
+          i++;
+          break;
+        } else {
+          value += sql[i];
+          i++;
+        }
+      }
+      tokens.push({ kind: "string", value });
+      continue;
+    }
+
+    if (c === '"') {
+      i++;
+      while (i < sql.length) {
+        if (sql[i] === '"' && sql[i + 1] === '"') i += 2;
+        else if (sql[i] === '"') {
+          i++;
+          break;
+        } else i++;
+      }
+      continue;
+    }
+
+    if (c === "$") {
+      const opener = sql.slice(i).match(/^\$[A-Za-z_][A-Za-z0-9_]*\$|^\$\$/)?.[0];
+      if (opener) {
+        const close = sql.indexOf(opener, i + opener.length);
+        i = close === -1 ? sql.length : close + opener.length;
+        continue;
+      }
+    }
+
+    if (isWordStart(c)) {
+      const start = i++;
+      while (i < sql.length && isWordPart(sql[i])) i++;
+      tokens.push({ kind: "word", value: sql.slice(start, i).toLowerCase() });
+      continue;
+    }
+
+    tokens.push({ kind: "punct", value: c });
+    i++;
+  }
+
+  return tokens;
+}
+
+// Extract decoded file path literals from a query, de-duplicated in first-seen
+// order. Registering bytes under the decoded name matches the filename DuckDB
+// resolves from the SQL string.
 export function extractFileLiterals(sql: string): string[] {
   const seen = new Set<string>();
   const out: string[] = [];
-  for (const re of [READER_RE, FROM_RE]) {
-    re.lastIndex = 0;
-    let m: RegExpExecArray | null;
-    while ((m = re.exec(sql)) !== null) {
-      const lit = m[1];
-      if (!seen.has(lit)) {
-        seen.add(lit);
-        out.push(lit);
-      }
+  const tokens = tokenizeSql(sql);
+
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    let literal: string | undefined;
+    if (
+      token.kind === "word" &&
+      READER_FNS.has(token.value) &&
+      tokens[i + 1]?.kind === "punct" &&
+      tokens[i + 1].value === "(" &&
+      tokens[i + 2]?.kind === "string"
+    ) {
+      literal = tokens[i + 2].value;
+    } else if (
+      token.kind === "word" &&
+      token.value === "from" &&
+      tokens[i + 1]?.kind === "string"
+    ) {
+      literal = tokens[i + 1].value;
+    }
+
+    if (literal !== undefined && !seen.has(literal)) {
+      seen.add(literal);
+      out.push(literal);
     }
   }
   return out;
@@ -46,8 +164,8 @@ export function extractFileLiterals(sql: string): string[] {
 // only vault-relative data files. Everything else is left for DuckDB to resolve
 // itself:
 //   - `scheme://...`  remote/OPFS URLs go through httpfs, no local copy needed.
-//   - absolute paths  (`/x`, `C:\x`) are real disk files, handled by the
-//                     read-only DB-file path, not the vault bridge.
+//   - absolute paths  (`/x`, `C:\x`) point outside the vault and aren't exposed
+//                     to DuckDB-Wasm by this bridge.
 //   - globs           (`*`, `?`, `[`) expand inside the engine over its VFS;
 //                     a single registered buffer can't satisfy them. Out of
 //                     scope for v1; left to error clearly.

--- a/src/query-block.ts
+++ b/src/query-block.ts
@@ -17,7 +17,12 @@ import { asDuckDbFrontmatter, type Connection, type DuckDbFrontmatter, type Quer
 export interface QueryBlockHost {
   app: App;
   settings: Settings;
-  runQuery(sql: string, connection: Connection, rowCap?: number): Promise<QueryRunResult>;
+  runQuery(
+    sql: string,
+    connection: Connection,
+    rowCap?: number,
+    sourcePath?: string,
+  ): Promise<QueryRunResult>;
   freezeRenderedBlock(
     ctx: MarkdownPostProcessorContext,
     el: HTMLElement,
@@ -158,6 +163,7 @@ export function renderQueryBlock(
           sql,
           connection,
           host.settings.rowCap,
+          ctx.sourcePath,
         );
         const dt = Math.round(performance.now() - t0);
         const rowsLabel = truncated ? `${rows.length}+ row(s)` : `${rows.length} row(s)`;

--- a/src/runtime/duckdb.ts
+++ b/src/runtime/duckdb.ts
@@ -141,6 +141,16 @@ export class DuckDBWasmRuntime implements Runtime {
     this.conn = await this.db.connect();
   }
 
+  // Register a file's bytes into DuckDB-Wasm's virtual filesystem under `name`.
+  // No parsing happens here — the bytes sit in the worker and DuckDB range-reads
+  // them when a query references `name`, so a Parquet still gets column/row-group
+  // pruning. The whole file is resident in memory though; the caller is
+  // responsible for gating size before reading it in.
+  async registerFile(name: string, bytes: Uint8Array): Promise<void> {
+    if (!this.db) await this.init();
+    await this.db!.registerFileBuffer(name, bytes);
+  }
+
   async runQuery(sql: string, rowCap?: number): Promise<QueryResult> {
     if (!this.conn) await this.init();
 

--- a/src/runtime/duckdb.ts
+++ b/src/runtime/duckdb.ts
@@ -151,6 +151,11 @@ export class DuckDBWasmRuntime implements Runtime {
     await this.db!.registerFileBuffer(name, bytes);
   }
 
+  async dropFile(name: string): Promise<void> {
+    if (!this.db) return;
+    await this.db.dropFile(name);
+  }
+
   async runQuery(sql: string, rowCap?: number): Promise<QueryResult> {
     if (!this.conn) await this.init();
 

--- a/src/runtime/file-registration.ts
+++ b/src/runtime/file-registration.ts
@@ -1,0 +1,36 @@
+import type { Runtime } from ".";
+
+export interface RegisteredFile {
+  name: string;
+  bytes: Uint8Array;
+}
+
+type FileRuntime = Pick<Runtime, "registerFile" | "dropFile">;
+
+export async function withRegisteredFiles<T>(
+  runtime: FileRuntime,
+  files: ReadonlyArray<RegisteredFile>,
+  operation: () => Promise<T>,
+  onDropError: (name: string, error: unknown) => void,
+): Promise<T> {
+  const registered: string[] = [];
+  try {
+    for (const file of files) {
+      // Track before awaiting so a registration that mutates the worker and
+      // then rejects is still cleaned up best-effort.
+      registered.push(file.name);
+      await runtime.registerFile(file.name, file.bytes);
+    }
+    return await operation();
+  } finally {
+    // Drop in reverse registration order and keep trying after a failure. A
+    // cleanup error must not replace the query result or its original error.
+    for (const name of registered.reverse()) {
+      try {
+        await runtime.dropFile(name);
+      } catch (e) {
+        onDropError(name, e);
+      }
+    }
+  }
+}

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -21,6 +21,13 @@ export interface Runtime {
    * materialized (legacy behavior, used for the public plugin API).
    */
   runQuery(sql: string, rowCap?: number): Promise<QueryResult>;
+  /**
+   * Make a file's bytes queryable under `name`, so SQL like
+   * `read_csv('<name>')` reads from these bytes instead of the host
+   * filesystem (which WASM can't reach). The bytes stay resident until the
+   * runtime is closed; re-registering the same name replaces them.
+   */
+  registerFile(name: string, bytes: Uint8Array): Promise<void>;
   close(): Promise<void>;
   label(): string;
 }

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -24,10 +24,12 @@ export interface Runtime {
   /**
    * Make a file's bytes queryable under `name`, so SQL like
    * `read_csv('<name>')` reads from these bytes instead of the host
-   * filesystem (which WASM can't reach). The bytes stay resident until the
-   * runtime is closed; re-registering the same name replaces them.
+   * filesystem (which WASM can't reach). The bytes stay resident until
+   * `dropFile` is called or the runtime is closed.
    */
   registerFile(name: string, bytes: Uint8Array): Promise<void>;
+  /** Release a file previously registered with `registerFile`. */
+  dropFile(name: string): Promise<void>;
   close(): Promise<void>;
   label(): string;
 }

--- a/src/runtime/manager.ts
+++ b/src/runtime/manager.ts
@@ -52,9 +52,15 @@ export class RuntimeManager {
     sql: string,
     connection: Connection,
     rowCap?: number,
+    files?: ReadonlyArray<{ name: string; bytes: Uint8Array }>,
   ): Promise<QueryRunResult> {
     return this.enqueueQuery(connection, async () => {
       const rt = await this.getRuntime(connection);
+      // Register inside the same queue slot as the query so a concurrent query
+      // on this connection can't run between registration and use.
+      if (files) {
+        for (const f of files) await rt.registerFile(f.name, f.bytes);
+      }
       return rt.runQuery(sql, rowCap);
     });
   }

--- a/src/runtime/manager.ts
+++ b/src/runtime/manager.ts
@@ -1,4 +1,5 @@
 import { DuckDBWasmRuntime } from "./duckdb";
+import { withRegisteredFiles, type RegisteredFile } from "./file-registration";
 import { MotherDuckRuntime } from "./motherduck";
 import type { Row, Runtime } from ".";
 import type { Connection, QueryRunResult, Settings } from "../types";
@@ -52,16 +53,20 @@ export class RuntimeManager {
     sql: string,
     connection: Connection,
     rowCap?: number,
-    files?: ReadonlyArray<{ name: string; bytes: Uint8Array }>,
+    files?: ReadonlyArray<RegisteredFile>,
   ): Promise<QueryRunResult> {
     return this.enqueueQuery(connection, async () => {
       const rt = await this.getRuntime(connection);
       // Register inside the same queue slot as the query so a concurrent query
       // on this connection can't run between registration and use.
-      if (files) {
-        for (const f of files) await rt.registerFile(f.name, f.bytes);
-      }
-      return rt.runQuery(sql, rowCap);
+      return withRegisteredFiles(
+        rt,
+        files ?? [],
+        () => rt.runQuery(sql, rowCap),
+        (name, e) => {
+          console.error(`[motherduck] failed to release registered file '${name}'`, e);
+        },
+      );
     });
   }
 

--- a/src/runtime/motherduck.ts
+++ b/src/runtime/motherduck.ts
@@ -24,6 +24,14 @@ export class MotherDuckRuntime implements Runtime {
     await this.connection.isInitialized();
   }
 
+  // Local vault files aren't bridged to the cloud connection — querying them
+  // would mean uploading, which the `motherduck` block doesn't do. No-op so the
+  // shared runQuery path can call this unconditionally; the file literal is left
+  // for MotherDuck to resolve (and error on) itself.
+  async registerFile(): Promise<void> {
+    // intentionally empty — see comment above
+  }
+
   async runQuery(sql: string, rowCap?: number): Promise<QueryResult> {
     if (!this.connection) await this.init();
 

--- a/src/runtime/motherduck.ts
+++ b/src/runtime/motherduck.ts
@@ -32,6 +32,10 @@ export class MotherDuckRuntime implements Runtime {
     // intentionally empty — see comment above
   }
 
+  async dropFile(): Promise<void> {
+    // Local vault files are never registered on the cloud runtime.
+  }
+
   async runQuery(sql: string, rowCap?: number): Promise<QueryResult> {
     if (!this.connection) await this.init();
 

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -63,6 +63,32 @@ export class SettingsTab extends PluginSettingTab {
           }),
       );
 
+    new Setting(this.containerEl)
+      .setName("Max local file size (MB)")
+      .setDesc(
+        createFragment((frag) => {
+          frag.appendText(
+            "A ",
+          );
+          frag.createEl("code", { text: "duckdb" });
+          frag.appendText(
+            " query can read files from your vault (e.g. read_csv('data/sales.csv')). The whole file is loaded into memory in the Obsidian process, so above this cap the query is refused — a file large enough to run out of memory can crash the window and lose unsaved edits. For large data, query a URL (httpfs) or MotherDuck instead. Set 0 to disable the limit.",
+          );
+        }),
+      )
+      .addText((t) =>
+        t
+          .setPlaceholder("1024")
+          .setValue(String(this.plugin.settings.maxLocalFileMB))
+          .onChange(async (v) => {
+            const n = parseInt(v, 10);
+            if (!Number.isNaN(n) && n >= 0) {
+              this.plugin.settings.maxLocalFileMB = Math.floor(n);
+              await this.plugin.saveSettings();
+            }
+          }),
+      );
+
     let duckdbStatusEl: HTMLSpanElement;
     new Setting(this.containerEl)
       .setName("Test DuckDB connection")

--- a/src/settings-tab.ts
+++ b/src/settings-tab.ts
@@ -64,7 +64,7 @@ export class SettingsTab extends PluginSettingTab {
       );
 
     new Setting(this.containerEl)
-      .setName("Max local file size (MB)")
+      .setName("Max local query data (MB)")
       .setDesc(
         createFragment((frag) => {
           frag.appendText(
@@ -72,7 +72,7 @@ export class SettingsTab extends PluginSettingTab {
           );
           frag.createEl("code", { text: "duckdb" });
           frag.appendText(
-            " query can read files from your vault (e.g. read_csv('data/sales.csv')). The whole file is loaded into memory in the Obsidian process, so above this cap the query is refused — a file large enough to run out of memory can crash the window and lose unsaved edits. For large data, query a URL (httpfs) or MotherDuck instead. Set 0 to disable the limit.",
+            " query can read files from your vault (e.g. read_csv('data/sales.csv')). The referenced files are loaded into memory in the Obsidian process, so a query whose combined file size exceeds this cap is refused — exhausting memory can crash the window and lose unsaved edits. For large data, query a URL (httpfs) or MotherDuck instead. Set 0 to disable the limit.",
           );
         }),
       )

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,12 @@ export const SWEEP_INTERVAL_MS = 60 * 60 * 1000;
 export const STARTUP_DELAY_MS = 5 * 1000;
 export const LOG_CAP = 100;
 
+// Local vault files are read fully into memory and handed to DuckDB-Wasm in the
+// renderer process. Above this size we warn (the load is noticeable); above the
+// configurable `maxLocalFileMB` cap we refuse, because OOMing the renderer can
+// take down the Obsidian window and lose unsaved edits.
+export const LOCAL_FILE_WARN_MB = 100;
+
 export interface RefreshLogEntry {
   ts: string;
   path: string;
@@ -29,6 +35,9 @@ export interface Settings {
   scheduleEnabled: boolean;
   resetAfterSchedule: boolean;
   refreshLog: RefreshLogEntry[];
+  // Max size (MB) of a vault file the plugin will read into memory for a
+  // `duckdb` query. 0 = no limit (power users who accept the OOM risk).
+  maxLocalFileMB: number;
 }
 
 export interface QueryRunResult {
@@ -51,6 +60,7 @@ export const DEFAULTS: Settings = {
   scheduleEnabled: false,
   resetAfterSchedule: true,
   refreshLog: [],
+  maxLocalFileMB: 1024,
 };
 
 export const AUTO_DISABLE_FAILURE_THRESHOLD = 3;

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,9 +13,9 @@ export const STARTUP_DELAY_MS = 5 * 1000;
 export const LOG_CAP = 100;
 
 // Local vault files are read fully into memory and handed to DuckDB-Wasm in the
-// renderer process. Above this size we warn (the load is noticeable); above the
-// configurable `maxLocalFileMB` cap we refuse, because OOMing the renderer can
-// take down the Obsidian window and lose unsaved edits.
+// renderer process. Above this aggregate query size we warn (the load is
+// noticeable); above the configurable `maxLocalFileMB` cap we refuse, because
+// OOMing the renderer can take down the Obsidian window and lose unsaved edits.
 export const LOCAL_FILE_WARN_MB = 100;
 
 export interface RefreshLogEntry {
@@ -35,8 +35,8 @@ export interface Settings {
   scheduleEnabled: boolean;
   resetAfterSchedule: boolean;
   refreshLog: RefreshLogEntry[];
-  // Max size (MB) of a vault file the plugin will read into memory for a
-  // `duckdb` query. 0 = no limit (power users who accept the OOM risk).
+  // Max combined size (MB) of vault files the plugin will read into memory for
+  // one `duckdb` query. 0 = no limit (power users who accept the OOM risk).
   maxLocalFileMB: number;
 }
 

--- a/test/file-registration.test.ts
+++ b/test/file-registration.test.ts
@@ -1,0 +1,107 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { withRegisteredFiles } from "../src/runtime/file-registration";
+
+function file(name: string) {
+  return { name, bytes: new Uint8Array([1]) };
+}
+
+test("withRegisteredFiles releases buffers after a successful operation", async () => {
+  const events: string[] = [];
+  const runtime = {
+    async registerFile(name: string) {
+      events.push(`register:${name}`);
+    },
+    async dropFile(name: string) {
+      events.push(`drop:${name}`);
+    },
+  };
+
+  const result = await withRegisteredFiles(
+    runtime,
+    [file("a.csv"), file("b.csv")],
+    async () => {
+      events.push("query");
+      return 42;
+    },
+    () => assert.fail("cleanup should not fail"),
+  );
+
+  assert.equal(result, 42);
+  assert.deepEqual(events, [
+    "register:a.csv",
+    "register:b.csv",
+    "query",
+    "drop:b.csv",
+    "drop:a.csv",
+  ]);
+});
+
+test("withRegisteredFiles releases registered buffers after errors", async () => {
+  const dropped: string[] = [];
+  const runtime = {
+    async registerFile() {},
+    async dropFile(name: string) {
+      dropped.push(name);
+    },
+  };
+  const queryError = new Error("query failed");
+
+  await assert.rejects(
+    withRegisteredFiles(
+      runtime,
+      [file("a.csv"), file("b.csv")],
+      async () => {
+        throw queryError;
+      },
+      () => assert.fail("cleanup should not fail"),
+    ),
+    (error) => error === queryError,
+  );
+  assert.deepEqual(dropped, ["b.csv", "a.csv"]);
+});
+
+test("withRegisteredFiles cleans up after a registration error", async () => {
+  const dropped: string[] = [];
+  const registerError = new Error("register failed");
+  const runtime = {
+    async registerFile(name: string) {
+      if (name === "b.csv") throw registerError;
+    },
+    async dropFile(name: string) {
+      dropped.push(name);
+    },
+  };
+
+  await assert.rejects(
+    withRegisteredFiles(
+      runtime,
+      [file("a.csv"), file("b.csv")],
+      async () => assert.fail("query should not run"),
+      () => assert.fail("cleanup should not fail"),
+    ),
+    (error) => error === registerError,
+  );
+  assert.deepEqual(dropped, ["b.csv", "a.csv"]);
+});
+
+test("withRegisteredFiles does not mask the query result when cleanup fails", async () => {
+  const cleanupErrors: Array<{ name: string; error: unknown }> = [];
+  const dropError = new Error("drop failed");
+  const runtime = {
+    async registerFile() {},
+    async dropFile() {
+      throw dropError;
+    },
+  };
+
+  const result = await withRegisteredFiles(
+    runtime,
+    [file("a.csv")],
+    async () => "ok",
+    (name, error) => cleanupErrors.push({ name, error }),
+  );
+
+  assert.equal(result, "ok");
+  assert.deepEqual(cleanupErrors, [{ name: "a.csv", error: dropError }]);
+});

--- a/test/local-files.test.ts
+++ b/test/local-files.test.ts
@@ -47,6 +47,31 @@ test("extractFileLiterals ignores non-file string literals", () => {
   );
 });
 
+test("extractFileLiterals ignores comments and quoted examples", () => {
+  const sql = `
+    -- read_csv('line-comment.csv')
+    /* read_parquet('block-comment.parquet') */
+    SELECT $$read_json('dollar-quoted.json')$$ AS example,
+           'read_csv(''ordinary-string.csv'')' AS another
+    FROM read_csv/* an inline comment */('real.csv')
+  `;
+  assert.deepEqual(extractFileLiterals(sql), ["real.csv"]);
+});
+
+test("extractFileLiterals decodes escaped apostrophes in paths", () => {
+  assert.deepEqual(
+    extractFileLiterals("SELECT * FROM read_csv('data/O''Brien.csv')"),
+    ["data/O'Brien.csv"],
+  );
+});
+
+test("extractFileLiterals preserves SQL order across reader and bare FROM forms", () => {
+  assert.deepEqual(
+    extractFileLiterals("FROM 'first.parquet' UNION ALL FROM read_csv('second.csv')"),
+    ["first.parquet", "second.csv"],
+  );
+});
+
 test("isVaultCandidate accepts vault-relative data paths", () => {
   assert.equal(isVaultCandidate("data/sales.csv"), true);
   assert.equal(isVaultCandidate("sales.csv"), true);

--- a/test/local-files.test.ts
+++ b/test/local-files.test.ts
@@ -1,0 +1,102 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import {
+  candidateVaultPaths,
+  extractFileLiterals,
+  isVaultCandidate,
+  normalizeVaultPath,
+} from "../src/local-files";
+
+test("extractFileLiterals pulls paths from reader functions", () => {
+  assert.deepEqual(
+    extractFileLiterals("SELECT * FROM read_csv('data/sales.csv')"),
+    ["data/sales.csv"],
+  );
+  assert.deepEqual(
+    extractFileLiterals("SELECT * FROM read_parquet('events.parquet') WHERE x > 1"),
+    ["events.parquet"],
+  );
+  // read_json / read_ndjson / *_auto variants, case-insensitive
+  assert.deepEqual(
+    extractFileLiterals("select * from READ_JSON_AUTO( 'a.json' )"),
+    ["a.json"],
+  );
+});
+
+test("extractFileLiterals handles bare FROM 'file'", () => {
+  assert.deepEqual(
+    extractFileLiterals("FROM 'reports/q1.parquet'"),
+    ["reports/q1.parquet"],
+  );
+});
+
+test("extractFileLiterals dedupes and preserves first-seen order", () => {
+  const sql = `
+    SELECT * FROM read_csv('a.csv') a
+    JOIN read_parquet('b.parquet') b USING (id)
+    WHERE a.x IN (SELECT x FROM read_csv('a.csv'))
+  `;
+  assert.deepEqual(extractFileLiterals(sql), ["a.csv", "b.parquet"]);
+});
+
+test("extractFileLiterals ignores non-file string literals", () => {
+  // A quoted value in a WHERE clause is not a reader argument.
+  assert.deepEqual(
+    extractFileLiterals("SELECT * FROM t WHERE name = 'cities.csv'"),
+    [],
+  );
+});
+
+test("isVaultCandidate accepts vault-relative data paths", () => {
+  assert.equal(isVaultCandidate("data/sales.csv"), true);
+  assert.equal(isVaultCandidate("sales.csv"), true);
+  assert.equal(isVaultCandidate("./sales.csv"), true);
+});
+
+test("isVaultCandidate rejects URLs, absolute paths, and globs", () => {
+  assert.equal(isVaultCandidate("https://example.com/x.csv"), false);
+  assert.equal(isVaultCandidate("s3://bucket/x.parquet"), false);
+  assert.equal(isVaultCandidate("opfs://x.csv"), false);
+  assert.equal(isVaultCandidate("/Users/me/x.csv"), false);
+  assert.equal(isVaultCandidate("C:\\data\\x.csv"), false);
+  assert.equal(isVaultCandidate("C:/data/x.csv"), false);
+  assert.equal(isVaultCandidate("data/*.parquet"), false);
+  assert.equal(isVaultCandidate("data/file?.csv"), false);
+  assert.equal(isVaultCandidate(""), false);
+});
+
+test("normalizeVaultPath resolves . and .. segments", () => {
+  assert.equal(normalizeVaultPath("a/./b/c"), "a/b/c");
+  assert.equal(normalizeVaultPath("a/b/../c"), "a/c");
+  assert.equal(normalizeVaultPath("notes/../data/x.csv"), "data/x.csv");
+});
+
+test("candidateVaultPaths tries note folder first, then vault root", () => {
+  assert.deepEqual(
+    candidateVaultPaths("sales.csv", "finance/2026/report.md"),
+    ["finance/2026/sales.csv", "sales.csv"],
+  );
+});
+
+test("candidateVaultPaths resolves relative subfolders against the note", () => {
+  assert.deepEqual(
+    candidateVaultPaths("data/sales.csv", "finance/report.md"),
+    ["finance/data/sales.csv", "data/sales.csv"],
+  );
+});
+
+test("candidateVaultPaths handles a note at the vault root", () => {
+  // No folder prefix -> single vault-root candidate.
+  assert.deepEqual(candidateVaultPaths("sales.csv", "report.md"), ["sales.csv"]);
+});
+
+test("candidateVaultPaths falls back to vault root with no note path", () => {
+  assert.deepEqual(candidateVaultPaths("data/sales.csv"), ["data/sales.csv"]);
+});
+
+test("candidateVaultPaths strips a leading ./", () => {
+  assert.deepEqual(
+    candidateVaultPaths("./sales.csv", "finance/report.md"),
+    ["finance/sales.csv", "sales.csv"],
+  );
+});


### PR DESCRIPTION
## What

A `duckdb` block can now read data files stored **in your vault**, by name:

```duckdb
SELECT country, count(*) FROM read_csv('data/cities.csv') GROUP BY 1
```

The plugin reads the file through Obsidian's vault adapter and registers the bytes into DuckDB-Wasm **before** the query runs, so the SQL is unchanged — DuckDB resolves registered names before hitting the filesystem (which WASM can't reach anyway). Paths resolve **relative to the note first**, then the vault root.

- Covers `read_csv` / `read_parquet` / `read_json` / `read_ndjson` (+ `_auto`) and bare `FROM 'file.parquet'`.
- Uses the cross-platform vault API, so it should work on **mobile** too — unlike the absolute-path DuckDB-file setting.

## Why this was needed

`read_csv('/local/path')` never worked in a query block: the engine runs in the DuckDB-Wasm worker with Node `process`/`Buffer` stripped, so it has no path to the host filesystem. The only existing disk read was the *DuckDB database-file* setting. This wires the vault adapter (`readBinary`) to `registerFileBuffer`, which is the one real bridge.

## Safety: size gate

Registering a buffer loads the **whole file into memory** in the Obsidian renderer. To avoid OOMing and crashing the window (losing unsaved edits):

- `adapter.stat().size` is checked **before reading** — never load-then-warn.
- The **combined size** of all referenced files is checked against **Settings → DuckDB → Max local query data** (default **1024 MB**, `0` = unlimited); over-limit queries are **refused before any file is read**.
- A single `Notice` warns when the combined query data exceeds 100 MB.

## Out of scope (deliberately)

Left to error clearly or to a URL/MotherDuck: **globs** (`data/*.csv`), **absolute paths outside the vault**, and **cloud `motherduck` blocks** (would mean uploading).

## Changes

- **New** `src/local-files.ts` — comment- and quote-aware SQL literal extraction + vault path resolution (no Obsidian/WASM deps).
- Query-scoped `registerFile()` / `dropFile()` lifecycle added to the `Runtime` interface; DuckDB-Wasm buffers are released after success, query errors, and partial registration failures.
- `manager.ts` registers and releases files **inside the query's queue slot** so concurrent queries can't interleave and buffers can't accumulate across queries.
- `main.ts` — `resolveLocalFiles()` (extract → resolve → `stat` gate → `readBinary`); `sourcePath` threaded through `runQuery` / `freezeBlock` / `processAllBlocks` and the three freeze callers.
- `query-block.ts` passes `ctx.sourcePath`; `types.ts` + `settings-tab.ts` add the cap.
- README ("Reading files from your vault") + `docs/demo.md` (section 6) + `docs/data/cities.csv` sample.

## Testing

- Build + eslint clean; **55/55** tests pass (**20 new** across local-file extraction and buffer-lifecycle tests).
- Verified the register→query mechanism end-to-end against the WASM engine: before registering, `read_csv('data/cities.csv')` errors *"No files found"* (confirming no host-fs leak); after `registerFileBuffer`, it returns the rows. Manual check in Obsidian still recommended for the live render path.

## Follow-ups (not in this PR)

- **Glob support** — expand via `adapter.list` and register each match.
- **Large local Parquet without the full copy** — test whether `adapter.getResourcePath`'s `app://` URL honors HTTP `Range`; if so, range-read in place via httpfs.

